### PR TITLE
Update docstring and apply weights to PID histograms

### DIFF
--- a/pisa/stages/pid/hist.py
+++ b/pisa/stages/pid/hist.py
@@ -95,9 +95,17 @@ class hist(Stage):
     ----------
     The `inputs` container must include objects with `name` attributes:
         * 'nue_cc'
+        * 'nue_nc'
+        * 'nuebar_cc'
+        * 'nuebar_nc'
         * 'numu_cc'
+        * 'numu_nc'
+        * 'numubar_cc'
+        * 'numubar_nc'
         * 'nutau_cc'
-        * 'nuall_nc'
+        * 'nutau_nc'
+        * 'nutaubar_cc'
+        * 'nutaubar_nc'
 
     Output Names
     ----------
@@ -304,7 +312,7 @@ class hist(Stage):
                 reco_params = [flav_sigdata[vn] for vn in var_names]
                 raw_histo[sig], _ = np.histogramdd(
                     sample=reco_params[:-1],
-                    weights=None, # --> reco_params[-1], # <-- (???)
+                    weights=reco_params[-1],
                     bins=all_bin_edges
                 )
                 total_histo += raw_histo[sig]


### PR DESCRIPTION
`reco_params` is an object that is just a renaming of `separated_events` for a particular flavint and pid_channel as a list, it contains the `reco_*` data and also on the last entry it contains the `weighted_aeff`, so that is what `reco_params[-1]` is - it is the `weighted_aeff` array
