### PR TITLE
Correct IO fiducial value for deltam31.

### DIFF
--- a/pisa/resources/settings/pipeline/example.cfg
+++ b/pisa/resources/settings/pipeline/example.cfg
@@ -369,6 +369,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/example_aeffsmooth.cfg
+++ b/pisa/resources/settings/pipeline/example_aeffsmooth.cfg
@@ -370,6 +370,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/example_deepcore.cfg
+++ b/pisa/resources/settings/pipeline/example_deepcore.cfg
@@ -338,6 +338,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/example_gpu.cfg
+++ b/pisa/resources/settings/pipeline/example_gpu.cfg
@@ -369,6 +369,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/example_recopid.cfg
+++ b/pisa/resources/settings/pipeline/example_recopid.cfg
@@ -315,6 +315,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/example_vbwkde.cfg
+++ b/pisa/resources/settings/pipeline/example_vbwkde.cfg
@@ -378,6 +378,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/nutau.cfg
+++ b/pisa/resources/settings/pipeline/nutau.cfg
@@ -329,6 +329,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/nutau_mc.cfg
+++ b/pisa/resources/settings/pipeline/nutau_mc.cfg
@@ -211,7 +211,7 @@ deltacp_nh = 306 units.deg
 deltacp_ih = 254 units.deg
 deltam21 = 7.5e-5 units.eV**2
 deltam31_nh = 0.002457  units.eV**2
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 
 [oscfit]
 # Atmospheric mixing parameters used for samples comparison

--- a/pisa/resources/settings/pipeline/test_vbwkde.cfg
+++ b/pisa/resources/settings/pipeline/test_vbwkde.cfg
@@ -378,6 +378,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/test_vbwkde_hist_ref.cfg
+++ b/pisa/resources/settings/pipeline/test_vbwkde_hist_ref.cfg
@@ -378,6 +378,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json

--- a/pisa/resources/settings/pipeline/xsec.cfg
+++ b/pisa/resources/settings/pipeline/xsec.cfg
@@ -247,6 +247,6 @@ deltam31_nh = 0.002457 units.eV**2
 deltam31_nh.prior = spline
 deltam31_nh.prior.data = priors/nufit2.json
 
-deltam31_ih = -0.002449 units.eV**2
+deltam31_ih = -0.002374 units.eV**2
 deltam31_ih.prior = spline
 deltam31_ih.prior.data = priors/nufit2.json


### PR DESCRIPTION
The nufit2 value for deltam31 (IO) in our settings files actually corresponds to deltam32 (IO) - this should be corrected (see comment below table at http://www.nu-fit.org/?q=node/92). Both in our cpu and gpu versions of prob3++, the wrappers around the code that does the actual computation expect deltam31. Cf. https://github.com/jllanfranchi/pisa/blob/cake/pisa/stages/osc/prob3/BargerPropagator.cc#L419 and https://github.com/jllanfranchi/pisa/blob/cake/pisa/stages/osc/prob3gpu.py#L403. In the first case, it seems to be possible to change this default behaviour (see https://github.com/jllanfranchi/pisa/blob/cake/pisa/stages/osc/prob3/BargerPropagator.h#L112), but as far as I can see we're not doing that anywhere.
