### PR TITLE
Create FlavIntDataGroup

### DIFF
--- a/pisa/utils/flavInt.py
+++ b/pisa/utils/flavInt.py
@@ -1170,9 +1170,11 @@ class FlavIntDataGroup(dict):
     """Container class for storing data for some set(s) of NuFlavIntGroups
     (cf. FlavIntData, which stores one datum for each NuFlavInt separately)
 
-    val
+    Parameters
+    ----------
+    val: None, str, or dict
         Data with which to populate the hierarchy
-    flavint_groups
+    flavint_groups: None, str, or iterable
         User-defined groupings of NuFlavIntGroups. These can be specified
         in several ways.
 
@@ -2152,7 +2154,7 @@ def test_FlavIntDataGroup():
     else:
         raise Exception
 
-    logging.info('<< PASS >> : FlavIntDataGroup')
+    logging.info('<< PASS : test_FlavIntDataGroup >>')
 
 
 def test_CombinedFlavIntData():


### PR DESCRIPTION
Simple implementation of a FlavIntData object which works for combinations of
NuFlavIntGroup's. Creates a single level dictionary of NuFlavIntGroup's in
which the data is then contained.

Mechanism added for adding two FlavIntDataGroup's which iterates down to the
lowest level of the dictionary until coincident numpy arrays are found, after
which the appropriate sub-element is made equal to the concatenation of the two
arrays.
