### PR TITLE
Spline prior constructor now accepts `units` argument (optional), so …

### DIFF
--- a/pisa/core/prior.py
+++ b/pisa/core/prior.py
@@ -532,7 +532,7 @@ def test_Prior():
 
     print '<< PASSED : test_Prior >>'
 
-
+# TODO: FIX ME
 def test_Prior_plot(ts_fname, param_name='theta23'):
     """Produce plots roughly like NuFIT's 1D chi-squared projections"""
     import matplotlib as mpl


### PR DESCRIPTION
…a prior object can be initialised from a (nufit) spline prior dict directly. Add a `valid_range` attribute to all kinds of priors. Make plotting method work.
