### PR TITLE
Cake aeff param mods

### DIFF
--- a/pisa/stages/aeff/param.py
+++ b/pisa/stages/aeff/param.py
@@ -1,14 +1,17 @@
 # PISA author: Timothy C. Arlen
 #
-# CAKE author: Thomas Ehrhardt
-#              tehrhardt@icecube.wisc.edu
-# date:        Oct 19, 2016
+# CAKE authors: Thomas Ehrhardt
+#               tehrhardt@icecube.wisc.edu
+#               Steven Wren
+#               steven.wren@icecube.wisc.edu
+# date:         Oct 19, 2016
 """
-This is an effective area service designed for quick studies of how effective
+This is an effective area stage designed for quick studies of how effective
 areas affect experimental observables and sensitivities. In addition, it is
-supposed to be easily reproducible as it solely relies on (phenomenological)
-functions, dependent on energy (and optionally cosine zenith), and which can
-thus be used as reference or benchmark scenarios.
+supposed to be easily reproducible as it may rely on (phenomenological)
+functions or interpolated discrete data points, dependent on energy
+(and optionally cosine zenith), and which can thus be used as reference or
+benchmark scenarios.
 """
 import copy
 from itertools import product


### PR DESCRIPTION
The initial goal of this was to add functionality to the parameterised aeff stage which turned out to already be there... duh. In the process, a few existing bugs were fixed, and some functionality was generalised (where this was fairly straightforward). Also, some things happening at transform computation time were moved to stage initialisation time. The pisa2 consistency script still passes, though I have to admit that I didn't test the various scenarios of certain "flavint" strings being present or not that could lead to exceptions. I'm fine with us keeping this as a PR here for now until someone gives the green light. Comments appreciated of course.