### PR TITLE
Make pipeline.py (the script) correctly parse param selections, and h…

### DIFF
--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -125,8 +125,9 @@ class DistributionMaker(object):
 
             if error_on_missing and successes == 0:
                 raise KeyError(
-                    'None of the selections %s found in any pipeline in this'
-                    ' distribution maker' %(selections,)
+                    'None of the stages from any pipeline in this distribution'
+                    ' maker has all of the selections %s available.'
+                    %(selections,)
                 )
         else:
             for pipeline in self:
@@ -310,7 +311,7 @@ def parse_args():
         help='''Settings file for each pipeline (repeat for multiple).'''
     )
     parser.add_argument(
-        '--select', metavar='PARAM_SELECTIONS', nargs='*',
+        '--select', metavar='PARAM_SELECTIONS', nargs='+', default=None,
         help='''Param selectors (separated by spaces) to use to override any
         defaults in the config file.'''
     )

--- a/pisa/core/pipeline.py
+++ b/pisa/core/pipeline.py
@@ -277,8 +277,8 @@ class Pipeline(object):
 
         if error_on_missing and successes == 0:
             raise KeyError(
-                'None of the selections %s was found in any stage in this'
-                ' pipeline.' %(selections,)
+                'None of the stages in this pipeline has all of the'
+                ' selections %s available.' %(selections,)
             )
 
     @property
@@ -403,7 +403,7 @@ def parse_args():
         help='File containing settings for the pipeline.'
     )
     parser.add_argument(
-        '--select', metavar='PARAM_SELECTIONS', nargs='*',
+        '--select', metavar='PARAM_SELECTIONS', nargs='+', default=None,
         help='''Param selectors (separated by spaces) to use to override any
         defaults in the config file.'''
     )

--- a/pisa/core/stage.py
+++ b/pisa/core/stage.py
@@ -663,7 +663,7 @@ class Stage(object):
                 selections, error_on_missing=True
             )
         except KeyError:
-            msg = 'None of the selections %s found in this pipeline.' \
+            msg = 'Not all of the selections %s found in this stage.' \
                     %(selections,)
             if error_on_missing:
                 #logging.error(msg)


### PR DESCRIPTION
…armonise this behaviour with that in distribution_maker.py (the script), cf. #305. In my eyes this solution is simple and at the same time more intuitive with respect to the required input format. `pipeline.py` will now also raise an exception if "none" (sic!) of the selectors are found in any of the stages. From the behaviour, I'd deduce that this should actually say "at least one" of the selectors wasn't found in any of the stages.