### PR TITLE
Make `Events.applyCut` return `Events` object whether the cut has alr…

### DIFF
--- a/pisa/core/events.py
+++ b/pisa/core/events.py
@@ -291,7 +291,9 @@ class Events(FlavIntData):
 
         """
         if keep_criteria in self.metadata['cuts']:
-            return
+            logging.debug("Criteria '%s' have already been applied. Returning"
+                          " events unmodified."%keep_criteria)
+            return self
 
         assert isinstance(keep_criteria, basestring)
 
@@ -354,6 +356,10 @@ class Events(FlavIntData):
         current_cuts = self.metadata['cuts']
         new_cuts = [dim.inbounds_criteria for dim in binning]
         unapplied_cuts = [c for c in new_cuts if c not in current_cuts]
+        if not unapplied_cuts:
+            logging.debug("All inbounds criteria '%s' have already been"
+                          " applied. Returning events unmodified."%new_cuts)
+            return self
         all_cuts = deepcopy(current_cuts) + unapplied_cuts
 
         # Create a single cut from all unapplied cuts


### PR DESCRIPTION
…eady been applied or not - code using method shouldn't depend on this distinction. Also prevent iteration over empty list when inbounds criteria have already been applied.

First issue: you create an `Events` instance `evts` and define some cut `mc_cut`. Then you apply it via `evts = evts.applyCut(mc_cut)` and assign it to itself as explained in the docstring. But if `mc_cut` has already been applied, `applyCut` returns `None`, and so you have overwritten `evts` with `None`, and any further code using `evts` will break.

Another error is associated with `unapplied_cuts` in `keepInbounds`, which might be empty if the criteria have already been applied. When this happens, `keep_criteria` (empty) are passed on to `applyCut`, and in there `mask = eval(crit_str)` fails with the error:

``` 
File "<string>", line unknown
    
    ^
SyntaxError: unexpected EOF while parsing
```

which is really not all that informative... 

I hope this makes sense.