### PR TITLE
fixing numba to v0.35, also adding note to install instructions (#459)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ Optional dependencies. Some of these must be installed manually prior to install
 
 * [llvm](http://llvm.org) Compiler needed by Numba. This is automatically installed in Anaconda alongside `numba`, but must be installed manually on your system otherwise.
   * Anaconda<br>
-    `conda install numba`
+    `conda install numba=0.35`
   * In Ubuntu,<br>
     `sudo apt install llvm-3.9-dev`
 * [virtualenv](https://virtualenv.pypa.io/en/stable/) Use virtual environments to e.g. create a "clean" installation and/or to have multiple multiple versions installed, one version per virtual environment. To speed up installation (at the cost of a less "clean" environment), you can specify the `--system-site-packages` option to `virtualenv` to make use of already-installed Python packages.
@@ -132,7 +132,7 @@ Optional dependencies. Some of these must be installed manually prior to install
 * [OpenMP](http://www.openmp.org) Intra-process parallelization to accelerate code on on multi-core/multi-CPU computers.
   * Available from your compiler: gcc supports OpenMP 4.0 and Clang >= 3.8.0 supports OpenMP 3.1. Either version of OpenMP should work, but Clang has yet to be tested for its OpenMP support.
 * [ROOT >= 6.12.04 with PyROOT](https://root.cern.ch) Necessary for `xsec.genie` and `unfold.roounfold` services, and to read ROOT cross section files in the `crossSections` utils module. Due to a bug in ROOT's python support (documented here https://github.com/jllanfranchi/pisa/issues/430), you need at least version 6.12.04 of ROOT.
-* [numba](http://numba.pydata.org) Just-in-time compilation of decorated Python functions to native machine code via LLVM. This can accelerate certain routines significantly. If not using Anaconda to install, you must have LLVM installed already on your system (see above).
+* [numba=0.35](http://numba.pydata.org) Just-in-time compilation of decorated Python functions to native machine code via LLVM. This package is required to use PISA pi; also in cake it can accelerate certain routines significantly. If not using Anaconda to install, you must have LLVM installed already on your system (see above).
   * Installed alongside PISA if you specify option `['numba']` to `pip`
 * [Pylint](http://www.pylint.org): Static code checker and style analyzer for Python code. Note that our (more or less enforced) coding conventions are codified in the pylintrc file in PISA, which will automatically be found and used by Pylint when running on code within a PISA package.<br>
   * Installed alongside PISA if you specify option `['develop']` to `pip`
@@ -286,6 +286,7 @@ This file lives at `$PISA/requirements.txt`.
 * If a specific compiler is set by the `CC` environment variable, it will be used, otherwise the `cc` command will be invoked on the system. Note that there have been some problems using `clang` under OSX, since versions of Clang older than 3.8.0 do not support `OpenMP`. Upgrade Clang or use `gcc` (if installed) and specify its executable with `CC` environment variable.
 
 __Notes:__
+* For PISA pi modules, the optional `numba` dependency is required
 * You can work with your installation using the usual git commands (pull, push, etc.). However, these ***won't recompile*** any of the extension (i.e. pyx, _C/C++_) libraries. See below for how to handle this case.
 * To test if your system compiled the gaussins.pyx Cython file with OpenMP threading support (and to see the speedup you can get using multiple cores for this module), you can run the following test script:
   `python $PISA/pisa/utils/test_gaussians.py --speed`

--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ def do_setup():
             ],
             'numba': [
                 'llvmlite>=0.16', # fastmath jit flag
-                'numba>=0.31' # fastmath jit flag
+                'numba==0.35' # fastmath jit flag, version fixed because of issue #439
             ],
             'develop': [
                 'pylint>=1.7',
@@ -314,7 +314,7 @@ def do_setup():
             # URL (e.g. the data). Plus it's huge (~1GB).
             #'mceq': [
             #    'llvmlite>=0.16',
-            #    'numba>=0.31',
+            #    'numba==0.35',
             #    'progressbar',
             #    'MCEq'
             #]


### PR DESCRIPTION
* fixing numba to v0.35, also adding note to install instructions, adding version number everywhere