### PR TITLE
Parse param config for log-scaling

### DIFF
--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -89,6 +89,11 @@ class Param:
 
     is_discrete : bool, optional
         Default is False
+    
+    scales_as_log : bool, optional
+        Rescale the log of the parameter's value between 0 and 1 for minimization,
+        rather than the value itself. This can help optimizing parameters spanning
+        several orders of magnitude.
 
     nominal_value : same type as `value`, optional
         If None (default), set to same as `value`

--- a/pisa/utils/config_parser.py
+++ b/pisa/utils/config_parser.py
@@ -470,6 +470,9 @@ def parse_param(config, section, selector, fullname, pname, value):
     # Search for explicit attr specifications
     if config.has_option(section, fullname + '.fixed'):
         kwargs['is_fixed'] = config.getboolean(section, fullname + '.fixed')
+        
+    if config.has_option(section, fullname + '.scales_as_log'):
+        kwargs['scales_as_log'] = config.getboolean(section, fullname + '.scales_as_log')
 
     if config.has_option(section, fullname + '.unique_id'):
         kwargs['unique_id'] = config.get(section, fullname + '.unique_id')


### PR DESCRIPTION
Added the log-scaling option to the config parser and added a doc-string to the option. 