### PR TITLE
Implement fast histogramming and lookup

### DIFF
--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -1841,6 +1841,21 @@ class MultiDimBinning(object):
         """Return a list of the contained dimensions' bin_edges that is
         compatible with the numpy.histogramdd `hist` argument."""
         return [d.bin_edges for d in self]
+    
+    @property
+    def is_irregular(self):
+        """Returns `True` if any of the 1D binnings is irregular."""
+        return np.any([d.is_irregular for d in self])
+    
+    @property
+    def is_lin(self):
+        """Returns `True` iff all dimensions are linear."""
+        return np.all([d.is_lin for d in self])
+    
+    @property
+    def is_log(self):
+        """Returns `True` iff all dimensions are log."""
+        return np.all([d.is_log for d in self])
 
     @property
     def domains(self):

--- a/pisa/core/stage.py
+++ b/pisa/core/stage.py
@@ -17,7 +17,6 @@ from pisa.core.binning import MultiDimBinning
 from pisa.core.container import ContainerSet
 from pisa.utils.log import logging
 from pisa.utils.format import arg_to_tuple
-from pisa.utils.profiler import profile
 from pisa.core.param import ParamSelector
 from pisa.utils.format import arg_str_seq_none
 from pisa.utils.hash import hash_obj

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -19,12 +19,17 @@ from numba import guvectorize
 
 import numba
 
+# When binnings are fully regular, we can use this for super speed
+import fast_histogram as fh
+from collections import Iterable
+
 from pisa import FTYPE
 from pisa.core.binning import OneDimBinning, MultiDimBinning
 from pisa.utils.comparisons import recursiveEquality
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.numba_tools import myjit
 from pisa.utils import vectorizer
+from pisa.utils.profiler import line_profile, profile
 
 __all__ = [
     'resample',
@@ -104,17 +109,57 @@ def histogram(sample, weights, binning, averaged, apply_weights=True):
         wether to use weights or not
 
     """
-    flat_hist = histogram_np(sample, weights, binning, apply_weights=True)
-
+    if binning.is_irregular or not binning.is_lin:
+        flat_hist = histogram_np(sample, weights, binning, apply_weights=True)
+    else:
+        flat_hist = histogram_fh(sample, weights, binning, apply_weights=True)
     if averaged:
-        flat_hist_counts = histogram_np(sample, weights, binning, apply_weights=False)
-
+        if binning.is_irregular or not binning.is_lin:
+            flat_hist_counts = histogram_np(sample, weights, binning,
+                                            apply_weights=False)
+        else:
+            flat_hist_counts = histogram_fh(sample, weights, binning,
+                                            apply_weights=False)
         with np.errstate(divide='ignore', invalid='ignore'):
             flat_hist /= flat_hist_counts
             flat_hist = np.nan_to_num(flat_hist)
 
     return flat_hist
 
+def histogram_fh(sample, weights, binning, apply_weights=True):  # pylint: disable=missing-docstring
+    """Helper function for fast_histogram historams.
+    
+    This requires binnings to be fully regular and linear.
+    """
+    binning = MultiDimBinning(binning)
+    if binning.is_irregular or not binning.is_lin:
+        raise ValueError("Binning should be linearly-regular to use the fast_histogram library.")
+    ranges = [b.domain.m for b in binning]
+    bins = binning.num_bins
+    if isinstance(sample, np.ndarray):
+        if sample.ndim == 1:
+            _sample = (sample,)
+        else:
+            _sample = tuple(s for s in sample.T)
+    elif isinstance(sample, Iterable):
+        _sample = tuple(s for s in sample)
+    else:
+        raise ValueError("Sample should be either an (N, D) array, or an (N,) array, "
+                         "or a (D, N) array-like.")
+
+    if weights is not None and weights.ndim == 2:
+        # that means it's 1-dim data instead of scalars
+        hists = []
+        for i in range(weights.shape[1]):
+            w = weights[:, i] if apply_weights else None
+            hist = fh.histogramdd(sample=_sample, weights=w, bins=bins, range=ranges)
+            hists.append(hist.ravel())
+        flat_hist = np.stack(hists, axis=1)
+    else:
+        w = weights if apply_weights else None
+        hist = fh.histogramdd(sample=_sample, weights=w, bins=bins, range=ranges)
+        flat_hist = hist.ravel()
+    return flat_hist.astype(FTYPE)
 
 def histogram_np(sample, weights, binning, apply_weights=True):  # pylint: disable=missing-docstring
     """helper function for numpy historams"""
@@ -162,6 +207,97 @@ def lookup(sample, flat_hist, binning):
     """
     assert binning.num_dims <= 3, 'can only do up to 3D at the moment'
     bin_edges = [edges.magnitude for edges in binning.bin_edges]
+    
+    if not binning.is_irregular and binning.is_lin:
+        if flat_hist.ndim == 1:
+            hist_vals = np.zeros_like(sample[0])
+            if binning.num_dims == 1:
+                lookup_regular_1d(
+                    sample[0],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    out=hist_vals,
+                )
+            elif binning.num_dims == 2:
+                lookup_regular_2d(
+                    sample[0],
+                    sample[1],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    ymin=bin_edges[1][0],
+                    ymax=bin_edges[1][-1],
+                    ny=len(bin_edges[1]) - 1,
+                    out=hist_vals,
+                )
+            elif binning.num_dims == 3:
+                lookup_regular_3d(
+                    sample[0],
+                    sample[1],
+                    sample[2],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    ymin=bin_edges[1][0],
+                    ymax=bin_edges[1][-1],
+                    ny=len(bin_edges[1]) - 1,
+                    zmin=bin_edges[2][0],
+                    zmax=bin_edges[2][-1],
+                    nz=len(bin_edges[2]) - 1,
+                    out=hist_vals,
+                )
+
+            return hist_vals
+        elif flat_hist.ndim == 2:
+            hist_shape = (sample[0].size, flat_hist.shape[1])
+            hist_vals = np.zeros(hist_shape, dtype=FTYPE)
+            if binning.num_dims == 1:
+                lookup_regular_1d_array(
+                    sample[0],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    out=hist_vals,
+                )
+            elif binning.num_dims == 2:
+                lookup_regular_2d_array(
+                    sample[0],
+                    sample[1],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    ymin=bin_edges[1][0],
+                    ymax=bin_edges[1][-1],
+                    ny=len(bin_edges[1]) - 1,
+                    out=hist_vals,
+                )
+            elif binning.num_dims == 3:
+                lookup_regular_3d_array(
+                    sample[0],
+                    sample[1],
+                    sample[2],
+                    flat_hist,
+                    xmin=bin_edges[0][0],
+                    xmax=bin_edges[0][-1],
+                    nx=len(bin_edges[0]) - 1,
+                    ymin=bin_edges[1][0],
+                    ymax=bin_edges[1][-1],
+                    ny=len(bin_edges[1]) - 1,
+                    zmin=bin_edges[2][0],
+                    zmax=bin_edges[2][-1],
+                    nz=len(bin_edges[2]) - 1,
+                    out=hist_vals,
+                )
+
+            return hist_vals
+        else:
+            raise NotImplementedError()
 
     if flat_hist.ndim == 1:
         #print 'looking up 1D'
@@ -232,6 +368,92 @@ def lookup(sample, flat_hist, binning):
     return hist_vals
 
 
+@numba.jit(nopython=True)
+def lookup_regular_1d(x, flat_hist, xmin, xmax, nx, out):
+    normx = nx / (xmax - xmin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            ix = (int)((x[idx] - xmin) * normx)
+            out[idx] = flat_hist[ix]
+            continue
+        out[idx] = 0.
+
+@numba.jit(nopython=True)
+def lookup_regular_2d(x, y, flat_hist, xmin, xmax, nx, ymin, ymax, ny, out):
+    normx = nx / (xmax - xmin)
+    normy = ny / (ymax - ymin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            if y[idx] >= ymin and y[idx] < ymax:
+                ix = (int)((x[idx] - xmin) * normx)
+                iy = (int)((y[idx] - ymin) * normy)
+                out[idx] = flat_hist[iy + ny*ix]
+                continue
+        out[idx] = 0.
+
+@numba.jit(nopython=True)
+def lookup_regular_3d(x, y, z, flat_hist, xmin, xmax, nx, ymin, ymax, ny,
+                            zmin, zmax, nz, out):
+    normx = nx / (xmax - xmin)
+    normy = ny / (ymax - ymin)
+    normz = nz / (zmax - zmin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            if y[idx] >= ymin and y[idx] < ymax:
+                if z[idx] >= zmin and z[idx] < zmax:
+                    ix = (int)((x[idx] - xmin) * normx)
+                    iy = (int)((y[idx] - ymin) * normy)
+                    iz = (int)((z[idx] - zmin) * normz)
+                    out[idx] = flat_hist[iz + nz*iy + nz*ny*ix]
+                    continue
+        out[idx] = 0.
+
+@numba.jit(nopython=True)
+def lookup_regular_1d_array(x, flat_hist, xmin, xmax, nx, out):
+    normx = nx / (xmax - xmin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            ix = (int)((x[idx] - xmin) * normx)
+            for d in range(flat_hist.shape[1]):
+                out[idx][d] = flat_hist[ix][d]
+            continue
+        for d in range(flat_hist.shape[1]):
+            out[idx][d] = 0.
+
+@numba.jit(nopython=True)
+def lookup_regular_2d_array(x, y, flat_hist, xmin, xmax, nx, ymin, ymax, ny, out):
+    normx = nx / (xmax - xmin)
+    normy = ny / (ymax - ymin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            if y[idx] >= ymin and y[idx] < ymax:
+                ix = (int)((x[idx] - xmin) * normx)
+                iy = (int)((y[idx] - ymin) * normy)
+                for d in range(flat_hist.shape[1]):
+                    out[idx][d] = flat_hist[iy + ny*ix][d]
+                continue
+        for d in range(flat_hist.shape[1]):
+            out[idx][d] = 0.
+
+@numba.jit(nopython=True)
+def lookup_regular_3d_array(x, y, z, flat_hist, xmin, xmax, nx, ymin, ymax, ny,
+                            zmin, zmax, nz, out):
+    normx = nx / (xmax - xmin)
+    normy = ny / (ymax - ymin)
+    normz = nz / (zmax - zmin)
+    for idx in range(len(out)):
+        if x[idx] >= xmin and x[idx] < xmax:
+            if y[idx] >= ymin and y[idx] < ymax:
+                if z[idx] >= zmin and z[idx] < zmax:
+                    ix = (int)((x[idx] - xmin) * normx)
+                    iy = (int)((y[idx] - ymin) * normy)
+                    iz = (int)((z[idx] - zmin) * normz)
+                    for d in range(flat_hist.shape[1]):
+                        out[idx][d] = flat_hist[iz + nz*iy + nz*ny*ix][d]
+                    continue
+        for d in range(flat_hist.shape[1]):
+            out[idx][d] = 0.
+
 @myjit
 def find_index(val, bin_edges):
     """Find index in binning for `val`. If `val` is below binning range or is
@@ -261,7 +483,6 @@ def find_index(val, bin_edges):
         0 <= `bin_idx` <= num_bins - 1
 
     """
-    # TODO: support fast computation for lin and log binnings?
 
     num_edges = len(bin_edges)
     num_bins = num_edges - 1

--- a/pisa/stages/utils/hist.py
+++ b/pisa/stages/utils/hist.py
@@ -10,9 +10,10 @@ import numpy as np
 from pisa import FTYPE
 from pisa.core.stage import Stage
 from pisa.core.translation import histogram
-from pisa.core.binning import MultiDimBinning
-from pisa.utils.profiler import profile
+from pisa.core.binning import MultiDimBinning, OneDimBinning
+from pisa.utils.profiler import profile, line_profile
 from pisa.utils import vectorizer
+from pisa.utils.log import logging
 
 
 class hist(Stage):  # pylint: disable=invalid-name
@@ -30,7 +31,7 @@ class hist(Stage):  # pylint: disable=invalid-name
 
         assert self.calc_mode is not None
         assert self.apply_mode is not None
-
+        self.regularized_apply_mode = None
 
     def setup_function(self):
 
@@ -53,6 +54,57 @@ class hist(Stage):  # pylint: disable=invalid-name
                 self.data.representation = self.calc_mode
                 container['hist_transform'] = transform
 
+        elif self.calc_mode == "events":
+            if self.apply_mode.is_irregular:
+                # For dimensions where the binning is irregular, we pre-compute the 
+                # index that each sample falls into and then bin regularly in the index.
+                # For dimensions that are logarithmic, we add a linear binning in 
+                # the logarithm.
+                dimensions = []
+                for dim in self.apply_mode:
+                    if dim.is_irregular:
+                        # create a new axis with digitized variable
+                        varname = dim.name + "__" + self.apply_mode.name + "_idx"
+                        new_dim = OneDimBinning(
+                            varname,
+                            domain=[0, dim.num_bins],
+                            num_bins=dim.num_bins
+                        )
+                        dimensions.append(new_dim)
+                        for container in self.data:
+                            container.representation = "events"
+                            x = container[dim.name]
+                            # Compute the bin index each sample would fall into, and 
+                            # shift by -1 such that samples below the binning range
+                            # get assigned the index -1.
+                            x_idx = np.searchsorted(dim.bin_edges, x, side="right") - 1
+                            # To be consistent with numpy histogramming, we need to
+                            # shift those values that are exactly at the uppermost edge
+                            # down one index such that they are included in the highest
+                            # bin instead of being treated as an outlier.
+                            on_edge = (x == dim.bin_edges[-1])
+                            x_idx[on_edge] -= 1
+                            container[varname] = x_idx
+                    elif dim.is_log:
+                        # We don't compute the log of the variable just yet, this
+                        # will be done later during `apply_function` using the 
+                        # representation mechanism.
+                        new_dim = OneDimBinning(
+                            dim.name,
+                            domain=np.log(dim.domain.m),
+                            num_bins=dim.num_bins
+                        )
+                        dimensions.append(new_dim)
+                    else:
+                        dimensions.append(dim)
+                self.regularized_apply_mode = MultiDimBinning(dimensions)
+                logging.debug("Using regularized binning:\n" + str(self.regularized_apply_mode))
+            else:
+                self.regularized_apply_mode = self.apply_mode
+        else:
+            raise ValueError(f"unknown calc mode: {self.calc_mode}")
+    
+    @profile
     def apply_function(self):
 
         #if self.calc_mode == 'binned':
@@ -90,16 +142,24 @@ class hist(Stage):  # pylint: disable=invalid-name
 
         elif self.calc_mode == 'events':
             for container in self.data:
-                # calcualte errors
-
                 container.representation = self.calc_mode
-                sample = [container[name] for name in self.apply_mode.names]
+                sample = []
+                dims_log = [d.is_log for d in self.apply_mode]
+                for dim, is_log in zip(self.regularized_apply_mode, dims_log):
+                    if is_log:
+                        container.representation = "log_events"
+                        sample.append(container[dim.name])
+                    else:
+                        container.representation = "events"
+                        sample.append(container[dim.name])
                 weights = container['weights']
-
-                hist = histogram(sample, weights, self.apply_mode, averaged=False)
+                
+                # The hist is now computed using a binning that is completely linear
+                # and regular
+                hist = histogram(sample, weights, self.regularized_apply_mode, averaged=False)
 
                 if self.error_method == 'sumw2':
-                    sumw2 = histogram(sample, np.square(weights), self.apply_mode, averaged=False)
+                    sumw2 = histogram(sample, np.square(weights), self.regularized_apply_mode, averaged=False)
 
                 container.representation = self.apply_mode
                 


### PR DESCRIPTION
This PR implements fast histogramming with the `fast_histogram` package and fast lookup with dedicated numba functions for regular binnings. 

When binnings are fully regular and linear, the `fast_histogram` library is automatically used when Container contents are translated from arrays to histograms, and the fast lookup functions are used when Container contents are translated from binnings to arrays. 

Because the logarithm is a very costly operation (especially in double precision), regularizing binnings into log-space would be very slow and nearly negate the advantage from using fast histograms. To circumvent this problem, a mechanism is implemented in the Container class to cache the logarithm of array representations. There are now two array representations: "events" and "log_events". When the "log_events" representation is requested, the log is calculated event-wise. As with any other representation, the result is cached such that the log need not be calculated again unless the contents are changed via item assignment.

With these two changes, histogram and lookup operations for regular (linear or logarithmic) binnings are accelerated by a factor between 5-10, at least in artificial benchmarks with normally distributed data, without any need to change Pipeline configurations or stages. 

Finally, the `hist` stage automatically detects irregular axes in the output binning and pre-computes indices for these axes (typically the PID axis) such that a regular binning in the index can be used. This is all done automatically, such that every analysis, even one using an irregular output binning, can take advantage of fast histogramming.

Note
-------
Currently, not all features needed have been merged into the `fast_histogram` package for a release. For now, an installation from the source of [my fork's "xmax_fix" branch](https://github.com/atrettin/fast-histogram/tree/xmax_fix) is required. I'm pushing for an official release, but until then, I will keep this a draft.