### PR TITLE
Set number of threads globally with PISA_NUM_THREADS variable

### DIFF
--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -216,14 +216,15 @@ del cpu_targets, gpu_targets, parallel_targets
 PISA_NUM_THREADS = 1
 """Global limit for number of threads"""
 
-# ignore if target is not multicore
-if TARGET == 'parallel':
-    if 'PISA_NUM_THREADS' in os.environ:
-        PISA_NUM_THREADS = int(os.environ['PISA_NUM_THREADS'])
-        assert PISA_NUM_THREADS >= 1
-    else:
-        PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS
-    OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
+if 'PISA_NUM_THREADS' in os.environ:
+    PISA_NUM_THREADS = int(os.environ['PISA_NUM_THREADS'])
+    assert PISA_NUM_THREADS >= 1
+else:
+    PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS
+OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
+if TARGET == 'cpu' and PISA_NUM_THREADS > 1:
+    sys.stderr.write("[WARNING] PISA_NUM_THREADS > 1 will be ignored when PISA_TARGET "
+                     "is not `parallel`.\n")
 # Define HASH_SIGFIGS to set hashing precision based on FTYPE above; value here
 # is default (i.e. for FTYPE == np.float64)
 HASH_SIGFIGS = 12

--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -10,7 +10,9 @@ import os
 import sys
 import warnings
 
+import numba
 from numba import jit as numba_jit
+
 from numpy import (
     array, inf, nan,
     float32, float64,
@@ -64,6 +66,7 @@ __all__ = [
     'NUMBA_CUDA_AVAIL',
     'TARGET',
     'OMP_NUM_THREADS',
+    'PISA_NUM_THREADS',
     'FTYPE',
     'CTYPE',
     'ITYPE',
@@ -120,7 +123,6 @@ OMP_NUM_THREADS = 1
 if 'OMP_NUM_THREADS' in os.environ:
     OMP_NUM_THREADS = int(os.environ['OMP_NUM_THREADS'])
     assert OMP_NUM_THREADS >= 1
-
 
 NUMBA_CUDA_AVAIL = False
 def dummy_func(x):
@@ -210,7 +212,18 @@ if TARGET is not None and 'PISA_TARGET' in os.environ:
 
 del cpu_targets, gpu_targets, parallel_targets
 
+# Default to single thread, then try to read from env
+PISA_NUM_THREADS = 1
+"""Global limit for number of threads"""
 
+# ignore if target is not multicore
+if TARGET == 'parallel':
+    if 'PISA_NUM_THREADS' in os.environ:
+        PISA_NUM_THREADS = int(os.environ['PISA_NUM_THREADS'])
+        assert PISA_NUM_THREADS >= 1
+    else:
+        PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS
+    OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
 # Define HASH_SIGFIGS to set hashing precision based on FTYPE above; value here
 # is default (i.e. for FTYPE == np.float64)
 HASH_SIGFIGS = 12
@@ -263,7 +276,7 @@ if TARGET is None:
 elif TARGET == 'cpu':
     target_msg = 'numba is running on CPU (single core)' # pylint: disable=invalid-name
 elif TARGET == 'parallel':
-    target_msg = 'numba is running on CPU (multicore)' # pylint: disable=invalid-name
+    target_msg = f'numba is running on CPU (multicore) with {PISA_NUM_THREADS} cores' # pylint: disable=invalid-name
 elif TARGET == 'cuda':
     target_msg = 'numba is running on GPU' # pylint: disable=invalid-name
 ini_msgs.append(target_msg)

--- a/pisa/stages/osc/prob3numba/numba_osc_hostfuncs.py
+++ b/pisa/stages/osc/prob3numba/numba_osc_hostfuncs.py
@@ -70,7 +70,7 @@ def propagate_array(dm, mix, mat_pot, nubar, energy, densities, distances, proba
 
 @njit(
     [f"({FX}[:,:], {CX}[:,:], {CX}[:,:], {IX}, {FX}, {FX}[:], {FX}[:], {FX}[:,:])"],
-    target=TARGET,
+    parallel=TARGET == "parallel"
 )
 def propagate_scalar(
     dm, mix, mat_pot, nubar, energy, densities, distances, probability
@@ -97,7 +97,7 @@ def propagate_scalar(
         f"{CX}[:,:], "  # transition_matrix
         ")"
     ],
-    target=TARGET,
+    parallel=TARGET == "parallel"
 )
 def get_transition_matrix_hostfunc(
     nubar,
@@ -127,7 +127,7 @@ def get_transition_matrix_hostfunc(
     )
 
 
-@njit([f"({FX}, {FX}, {CX}[:,:], {CX}[:,:], {CX}[:,:], {CX}[:,:])"], target=TARGET)
+@njit([f"({FX}, {FX}, {CX}[:,:], {CX}[:,:], {CX}[:,:], {CX}[:,:])"], parallel=TARGET == "parallel")
 def get_transition_matrix_massbasis_hostfunc(
     baseline,
     energy,
@@ -148,28 +148,28 @@ def get_transition_matrix_massbasis_hostfunc(
     )
 
 
-@njit([f"({CX}[:,:], {CX}[:,:], {FX}[:,:], {CX}[:,:])"], target=TARGET)
+@njit([f"({CX}[:,:], {CX}[:,:], {FX}[:,:], {CX}[:,:])"], parallel=TARGET == "parallel")
 def get_H_vac_hostfunc(mix_nubar, mix_nubar_conj_transp, dm_vac_vac, H_vac):
     """wrapper to run `get_H_vac` from host (whether TARGET is "cuda" or "host")"""
     get_H_vac(mix_nubar, mix_nubar_conj_transp, dm_vac_vac, H_vac)
 
 
 # @guvectorize(
-#     [f"({FX}, {CX}[:,:], {IX}, {CX}[:,:])"], "(), (m, m), () -> (m, m)", target=TARGET
+#     [f"({FX}, {CX}[:,:], {IX}, {CX}[:,:])"], "(), (m, m), () -> (m, m)"
 # )
-@njit([f"({FX}, {CX}[:,:], {IX}, {CX}[:,:])"], target=TARGET)
+@njit([f"({FX}, {CX}[:,:], {IX}, {CX}[:,:])"], parallel=TARGET == "parallel")
 def get_H_mat_hostfunc(rho, mat_pot, nubar, H_mat):
     """wrapper to run `get_H_mat` from host (whether TARGET is "cuda" or "host")"""
     get_H_mat(rho, mat_pot, nubar, H_mat)
 
 
-@njit([f"({FX}, {CX}[:,:], {FX}[:,:], {CX}[:,:], {CX}[:,:])"], target=TARGET)
+@njit([f"({FX}, {CX}[:,:], {FX}[:,:], {CX}[:,:], {CX}[:,:])"], parallel=TARGET == "parallel")
 def get_dms_hostfunc(energy, H_mat, dm_vac_vac, dm_mat_mat, dm_mat_vac):
     """wrapper to run `get_dms` from host (whether TARGET is "cuda" or "host")"""
     get_dms(energy, H_mat, dm_vac_vac, dm_mat_mat, dm_mat_vac)
 
 
-@njit([f"({FX}, {CX}[:,:], {CX}[:,:], {CX}[:,:], {CX}[:,:,:])"], target=TARGET)
+@njit([f"({FX}, {CX}[:,:], {CX}[:,:], {CX}[:,:], {CX}[:,:,:])"], parallel=TARGET == "parallel")
 def get_product_hostfunc(
     energy, dm_mat_vac, dm_mat_mat, H_mat_mass_eigenstate_basis, product
 ):
@@ -177,7 +177,7 @@ def get_product_hostfunc(
     get_product(energy, dm_mat_vac, dm_mat_mat, H_mat_mass_eigenstate_basis, product)
 
 
-@njit([f"({IX}, {CX}[:,:], {CX}[:])"], target=TARGET)
+@njit([f"({IX}, {CX}[:,:], {CX}[:])"], parallel=TARGET == "parallel")
 def convert_from_mass_eigenstate_hostfunc(state, mix_nubar, psi):
     """wrapper to run `convert_from_mass_eigenstate` from host (whether TARGET
     is "cuda" or "host")"""
@@ -185,7 +185,7 @@ def convert_from_mass_eigenstate_hostfunc(state, mix_nubar, psi):
 
 
 @guvectorize(
-    [f"({FX}[:,:], {IX}, {IX}, {FX}[:])"], "(a,b), (), () -> ()", target=TARGET
+    [f"({FX}[:,:], {IX}, {IX}, {FX}[:])"], "(a,b), (), () -> ()"
 )
 def fill_probs(probability, initial_flav, flav, out):
     """Fill `out` with transition probabilities to go from `initial_flav` to

--- a/pisa/stages/osc/prob3numba/test_numba.py
+++ b/pisa/stages/osc/prob3numba/test_numba.py
@@ -63,7 +63,7 @@ def main():
     print("took %.5f" % (end_t - start_t))
     out
 
-    print(out.get("host"))
+    print(out)
 
 
 if __name__ == "__main__":

--- a/pisa/utils/numba_tools.py
+++ b/pisa/utils/numba_tools.py
@@ -63,10 +63,11 @@ from numba import (  # pylint: disable=unused-import
     jit,
 )
 
-from pisa import FTYPE, TARGET
+from pisa import FTYPE, TARGET, PISA_NUM_THREADS
 from pisa.utils.comparisons import ALLCLOSE_KW
 from pisa.utils.log import Levels, logging, set_verbosity
 
+numba.set_num_threads(PISA_NUM_THREADS)
 
 if TARGET is None:
     raise NotImplementedError("Numba not supported.")


### PR DESCRIPTION
This PR allows one to set the number of threads to be used for multithreading with one central environment variable `PISA_NUM_THREADS`. This variable is used by `numba` as well as any "custom" multithreading implementation (of which there is currently only one, for fast histograms). 

Multithreading can be made much more simple than we used to: All one needs to do is to implement things with simple for-loops and then use numba's `prange` instead of `range` in for-loops that can be naively parallelized. This is done for the `mceq_barr_red` stage as well as the fast lookup procedures. I would recommend going this route as well for `prob3`, but I don't think that I'm going to do this because I'm not using it myself. I had to remove the `target` keyword in some places because it no longer works.

nuSQuIDS already support multithreading for the most expensive operation of propagating state densities through matter potentials, and here, too, the `PISA_NUM_THREADS` variable is used.

Multithreading for fast histograms is possible because the Global Interpreter Lock is released during the main loop, allowing Python to continue during the calculation. The input sample is simply split up in chunks and the histogram is calculated for every chunk, and the outputs are added together. The speedup is not entirely a factor of N for N cores, but there is benefit in it.