### PR TITLE
Multithreading fix

### DIFF
--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -219,12 +219,20 @@ PISA_NUM_THREADS = 1
 if 'PISA_NUM_THREADS' in os.environ:
     PISA_NUM_THREADS = int(os.environ['PISA_NUM_THREADS'])
     assert PISA_NUM_THREADS >= 1
-else:
+    if TARGET == 'cpu' and PISA_NUM_THREADS > 1:
+        sys.stderr.write("[WARNING] PISA_NUM_THREADS > 1 will be ignored when "
+                         "PISA_TARGET is not `parallel`.\n")
+        PISA_NUM_THREADS = 1
+elif TARGET == 'parallel':
     PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS
+
+if TARGET == 'cpu':
+    # making sure that we can definitely rely on the fact that the number of threads
+    # will be 1 if the TARGET is `cpu` (some stages might do that)
+    assert PISA_NUM_THREADS == 1
+
 OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
-if TARGET == 'cpu' and PISA_NUM_THREADS > 1:
-    sys.stderr.write("[WARNING] PISA_NUM_THREADS > 1 will be ignored when PISA_TARGET "
-                     "is not `parallel`.\n")
+
 # Define HASH_SIGFIGS to set hashing precision based on FTYPE above; value here
 # is default (i.e. for FTYPE == np.float64)
 HASH_SIGFIGS = 12

--- a/pisa/stages/osc/nusquids.py
+++ b/pisa/stages/osc/nusquids.py
@@ -227,7 +227,7 @@ class nusquids(Stage):
         self.detector_depth = detector_depth.m_as("km")
         self.prop_height = prop_height.m_as("km")
         self.avg_height = False
-        self.concurrent_threads = PISA_NUM_THREADS
+        self.concurrent_threads = PISA_NUM_THREADS if TARGET == "parallel" else 1
         self.prop_height_range = None
         self.apply_height_avg_below_hor = apply_height_avg_below_hor
         if prop_height_range is not None:  # this is optional

--- a/pisa/utils/numba_tools.py
+++ b/pisa/utils/numba_tools.py
@@ -67,7 +67,8 @@ from pisa import FTYPE, TARGET, PISA_NUM_THREADS
 from pisa.utils.comparisons import ALLCLOSE_KW
 from pisa.utils.log import Levels, logging, set_verbosity
 
-numba.set_num_threads(PISA_NUM_THREADS)
+if TARGET == "parallel":
+    numba.set_num_threads(PISA_NUM_THREADS)
 
 if TARGET is None:
     raise NotImplementedError("Numba not supported.")


### PR DESCRIPTION
Because the nuSQuIDS stage didn't check whether the `TARGET` was `parallel`, it would use multicore despite the target being CPU. We now check whether the target is `parallel` and _in addition_ make sure that the global variable `PISA_NUM_THREADS` is always 1 if `TARGET` is `cpu`.

We also only give out the warning if the user tried to set `PISA_NUM_THREADS` in their environment explicitly larger than 1, but the `TARGET` is `cpu`.