### PR TITLE
Small fixes to analysis and param

### DIFF
--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -394,7 +394,7 @@ class Param:
 
     @tex.setter
     def tex(self, t):
-        self._tex = t if t is not None else r'{\rm %s}' % self.name
+        self._tex = t
 
     @property
     def nominal_value(self):


### PR DESCRIPTION
Just two small fixes: 
* Setting `reset_free` when doing a constrained fit should only reset just before the fit starts, but not on each iteration when the penalty is doubled. Otherwise, the entire fit would have to run again just because it ended up in a region that is not allowed, which would take a long time. 
* The `Param` class should not make up its own TeX name when it is set to `None`. Especially in this case, the TeX code was broken every time the name of the parameter had two underscores inside. Our plotting scripts check if the TeX property is None and if so, take the name string instead of the tex string.