### PR TITLE
Support iminuit 2.x for hypersurfaces and local fits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ INSTALL_REQUIRES = [
     'kde @ git+https://github.com/icecubeopensource/kde.git',
     'fast-histogram @ git+https://github.com/atrettin/fast-histogram.git',
     'h5py',
-    'iminuit<2',
+    'iminuit>=2',
     'line_profiler',
     'matplotlib>=3.0', # 1.5: inferno colormap; 2.0: 'C0' colorspec
     'numba>=0.53', # >=0.35: fastmath jit flag; >=0.38: issue #439; 0.44 segfaults


### PR DESCRIPTION
This PR fixes issue #649 and adds iminuit as yet another option to the toolkit of the Analysis class. It can be dropped in place of local scipy optimization by setting `local_fit_kwargs` to a dictionary with the following content:

```
minuit_settings = {
    "errors": 0.1,  # initial Migrad step size, not very important
    "precision": 1e-14,  # default: double precision
    "tol": 0.1,  # default: 0.1
    "run_simplex": True  # run simplex before polishing the result with Migrad (default: False)
    "run_migrad": True  # run migrad (default: True). If `False`, runs only Simplex and exits
}

local_fit_kwargs = {
    "method": "iminuit",
    "method_kwargs": minuit_settings,
    "local_fit_kwargs": None  # minuit is a local optimization and therefore ends the recursion
}
```

The `errordef` option is automatically set depending on the type of loss function being optimized.
When both Simplex and Migrad are run, Simplex stops at a relatively lax tolerance and the result is polished with Migrad.