### PR TITLE
Correct handling of selectable params

### DIFF
--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -185,9 +185,18 @@ class DistributionMaker(object):
         # set parameters with an identical name to the same object
         # otherwise we get inconsistent behaviour when setting repeated params
         # See Isues #566 and #648
-        all_parans = self.params
+        # Also, do this for all selections!
+        original_selection = self.param_selections
+        all_selections = set()
         for pipeline in self:
-            pipeline.update_params(all_parans, existing_must_match=True, extend=False)
+            for stage in pipeline.stages:
+                all_selections.update(stage._param_selector._selector_params.keys())
+        for selection in all_selections:
+            self.select_params(selection)
+            all_params = self.params
+            for pipeline in self:
+                pipeline.update_params(all_params, existing_must_match=True, extend=False)
+        self.select_params(original_selection)
 
     def __repr__(self):
         return self.tabulate(tablefmt="presto")

--- a/pisa/core/param.py
+++ b/pisa/core/param.py
@@ -1324,7 +1324,7 @@ class ParamSelector:
             return False
         return True
 
-    def update(self, p, selector=None):
+    def update(self, p, selector=None, existing_must_match=False, extend=True):
         try:
             p = ParamSet(p)
         except:
@@ -1333,14 +1333,17 @@ class ParamSelector:
             raise
 
         if selector is None:
-            self._regular_params.update(p)
-            self._current_params.update(p)
+            self._regular_params.update(p, existing_must_match=existing_must_match, extend=extend)
+            self._current_params.update(p, existing_must_match=existing_must_match, extend=extend)
+            for selection in self._selections:
+                if selection in self._selector_params.keys():
+                    self._selector_params[selection].update(p, existing_must_match=existing_must_match, extend=extend)
         else:
             assert isinstance(selector, str)
             selector = selector.strip().lower()
             if selector not in self._selector_params:
                 self._selector_params[selector] = ParamSet()
-            self._selector_params[selector].update(p)
+            self._selector_params[selector].update(p, existing_must_match=existing_must_match, extend=extend)
 
             # Re-select current selectiosn in case the update modifies these
             self.select_params(error_on_missing=False)

--- a/pisa/core/pipeline.py
+++ b/pisa/core/pipeline.py
@@ -353,7 +353,8 @@ class Pipeline(object):
 
         """
         for stage in self:
-            stage.params.update(params, existing_must_match=existing_must_match, extend=extend)
+            stage._param_selector.update(params, existing_must_match=existing_must_match, extend=extend)
+            #stage.params.update(params, existing_must_match=existing_must_match, extend=extend)
 
     def select_params(self, selections, error_on_missing=False):
         """Select a set of alternate param values/specifications.

--- a/pisa/stages/README.md
+++ b/pisa/stages/README.md
@@ -2,18 +2,92 @@
 
 Directories are PISA stages, and within each directory can be found the services implementing the respective stage.
 
-# Anatomy of a Stage
+## Anatomy of a typical stage
 
-The PISA stage inherits from pisa.core.stage.Stage
+### Constructor
+The constructor of the stage should look like the following:
 
-There are 4 pasrts to a stage:
+```python
+class mystage(Stage):
+  """
+  Docstring (mandatory!)
+  
+  What is the purpose of this stage? Short 1-2 sentence description
+  
+  Parameters:
+  -----------
+  
+  params :
+    Expected params are .. ::
+      a : dimensionless Quantity
+      b : dimensionless Quantity
+  
+  something_else : float
+    Description
+    
+  Notes:
+  ------
+  
+  More info, references, etc...
+  
+  """
+  def __init__(self, something_else, **std_kwargs):
 
-## The constructor
+    expected_params = ('a', 'b')
+    
+    super().__init__(expected_params=expected_params, **std_kwargs)
+    
+    self.foo = something_else
+```
 
-Assign here any arguments passed in via the config, define expected parameters, and init the base stage
+The constructor arguments are passed in via the satage config file, which in this case would need to look something like:
 
-## The setup function
+ ```ini
+ [stage_dir.mystage]
 
-## The calculation function
+calc_mode = ...
+apply_mode = ...
 
-## The apply function
+something_else = 42.
+
+params.a = 13.
+params.b = 27.3 +/- 3.2
+```
+
+The `std_kwargs` can only contain `data, params, debug_mode, error_mode, calc_mode, apply_mode, profile`, of which `data` and `params` will be autmoatically populated.
+
+
+### Methods
+
+The stages can implement three standard methods:
+* `setup_function` : executed upon instantiation (and in the future potentially for more)
+* `compute_function` : executed in a run if parameters changed (and first run)
+* `apply_function` : executed in every run
+
+The data representation is set by default to `calc_mode` for the first two, and `apply_mode` in the latter, but can be changed by the user freely.
+
+An example of such an above function could look like:
+
+```python
+
+def apply_function(self):
+  b_magnitude = self.params.b.m_as('dimensionless')
+  
+  for container in self.data:
+    container['weights'] *= b_magnitude
+```
+**N.B.:** If you use in-place array operations on your containers (e.g. `container['weights'][mask] = 0.0`, you need to mark thses changes via `container.mark_changed('weights')`)
+
+## Directory Listing
+
+* `aeff/` - All stages relating to effective area transforms.
+* `combine/` - A stage for combining maps together and applying appropriate scaling factors. 
+* `data/` - All stages relating to the handling of data.
+* `discr_sys/` - All stages relating to the handling of discrete systematics.
+* `flux/` - All stages relating to the atmospheric neutrino flux.
+* `osc/` - All stages relating to neutrino oscillations. 
+* `pid/` - All stages relating to particle identification.
+* `reco/` - All stages relating to applying reconstruction kernels.
+* `unfold/` - All stages relating to the unfolding of parameters from data.
+* `xsec/` - All stages relating to cross sections.
+* `__init__.py` - File that makes the `stages` directory behave as a Python module.


### PR DESCRIPTION
Before, only the current representation of the selectable params would get overwritten in the distributionmaker instantiation, such that params of the same name would point to the same object.
Furthermore, the update function in the pipeline would call update on the params instead of the selector.
Also, the update in param selector would ignore the values in the underlying dict