### PR TITLE
Implement KDE bootstrapped error estimates and more

### DIFF
--- a/pisa/stages/aeff/weight.py
+++ b/pisa/stages/aeff/weight.py
@@ -17,6 +17,7 @@ class weight(Stage):  # pylint: disable=invalid-name
 
     Parameters
     ----------
+
     params : ParamSet or sequence with which to instantiate a ParamSet.
         Expected params are: .. ::
 
@@ -47,3 +48,5 @@ class weight(Stage):  # pylint: disable=invalid-name
 
         for container in self.data:
             container['weights'] *= scale
+            if "errors" in container.keys:
+                container["errors"] *= scale

--- a/pisa/stages/utils/kde.py
+++ b/pisa/stages/utils/kde.py
@@ -1,4 +1,3 @@
-
 """
 Stage to transform arrays with weights into KDE maps
 that represent event counts
@@ -8,10 +7,12 @@ import numpy as np
 
 from pisa import FTYPE, TARGET
 from pisa.core.stage import Stage
+from pisa.core.binning import MultiDimBinning, OneDimBinning
 from pisa.utils.log import logging
 from pisa.utils.profiler import profile
 from pisa.utils import vectorizer
 from pisa.utils.kde_hist import kde_histogramdd
+
 
 class kde(Stage):
     """stage to KDE-map events
@@ -26,6 +27,13 @@ class kde(Stage):
         treatment for reflection
     oversample : int
         Evaluate KDE at more points per bin, takes longer, but is more accurate
+    stash_hists : bool
+        Evaluate KDE only once and stash the result. This effectively ignores all changes
+        from earlier stages, but greatly increases speed. Useful for muons where
+        only over-all weight and detector systematic variations matter, which can both
+        be applied on the histograms after this stage.
+    bootstrap : bool
+        Use the bootstrapping technique to estimate errors on the KDE histograms.
 
     Notes
     -----
@@ -34,26 +42,68 @@ class kde(Stage):
     binning range, otherwise events will only "bleed out"
 
     """
-    def __init__(self,
-                 bw_method='silverman',
-                 coszen_name='reco_coszen',
-                 oversample=10,
-                 coszen_reflection=0.25,
-                 stack_pid=True,
-                 **std_kargs,
-                ):
+
+    def __init__(
+        self,
+        bw_method="silverman",
+        coszen_name="reco_coszen",
+        oversample=10,
+        coszen_reflection=0.25,
+        stack_pid=True,
+        stash_hists=False,
+        bootstrap=False,
+        bootstrap_niter=10,
+        **std_kargs,
+    ):
 
         self.bw_method = bw_method
         self.coszen_name = coszen_name
         self.oversample = int(oversample)
         self.coszen_reflection = coszen_reflection
         self.stack_pid = stack_pid
+        self.stash_hists = stash_hists
+        self.stash_valid = False
+        self.bootstrap = bootstrap
+        self.bootstrap_niter = bootstrap_niter
+
+        if stash_hists:
+            self.stashed_hists = None
+            if self.bootstrap:
+                self.stashed_errors = None
 
         # init base class
         super().__init__(
             expected_params=(),
             **std_kargs,
         )
+
+        assert self.calc_mode == "events"
+        self.regularized_apply_mode = None
+
+    def setup_function(self):
+
+        assert isinstance(self.apply_mode, MultiDimBinning), (
+            f"KDE stage needs a binning as `apply_mode`, but is {self.apply_mode}"
+        )
+
+        # For dimensions that are logarithmic, we add a linear binning in
+        # the logarithm.
+        dimensions = []
+        for dim in self.apply_mode:
+            if dim.is_log and not dim.is_irregular:
+                # We don't compute the log of the variable just yet, this
+                # will be done later during `apply_function` using the
+                # representation mechanism.
+                new_dim = OneDimBinning(
+                    dim.name,
+                    domain=np.log(dim.domain.m),
+                    num_bins=dim.num_bins
+                )
+                dimensions.append(new_dim)
+            else:
+                dimensions.append(dim)
+            self.regularized_apply_mode = MultiDimBinning(dimensions)
+            logging.debug("Using regularized binning:\n" + repr(self.regularized_apply_mode))
 
     @profile
     def apply(self):
@@ -62,24 +112,67 @@ class kde(Stage):
         # normally in a stage you would implement the `apply_function` method
         # and not the `apply` method!
 
-        binning = self.apply_mode
-
         for container in self.data:
-            self.data.representation = self.calc_mode
-            sample = np.stack([container[n] for n in binning.names]).T
-            weights = container['weights']
 
-            kde_map = kde_histogramdd(sample=sample,
-                            binning=binning,
-                            weights=weights,
-                            bw_method=self.bw_method,
-                            coszen_name=self.coszen_name,
-                            coszen_reflection=self.coszen_reflection, 
-                            oversample=self.oversample,
-                            use_cuda=False,
-                            stack_pid=self.stack_pid)
+            if self.stash_valid:
+                self.data.representation = self.apply_mode
+                # Making a copy of the stash so that subsequent stages will not manipulate
+                # it.
+                container["weights"] = self.stashed_hists[container.name].copy()
+                if self.bootstrap:
+                    container["errors"] = self.stashed_errors[container.name].copy()
+                continue
 
+            sample = []
+            dims_log = [d.is_log for d in self.apply_mode]
+            for dim, is_log in zip(self.regularized_apply_mode, dims_log):
+                if is_log:
+                    container.representation = "log_events"
+                    sample.append(container[dim.name])
+                else:
+                    container.representation = "events"
+                    sample.append(container[dim.name])
+
+            sample = np.stack(sample).T
+            weights = container["weights"]
+
+            kde_kwargs = dict(
+                sample=sample,
+                binning=self.regularized_apply_mode,
+                weights=weights,
+                bw_method=self.bw_method,
+                coszen_name=self.coszen_name,
+                coszen_reflection=self.coszen_reflection,
+                oversample=self.oversample,
+                use_cuda=False,
+                stack_pid=self.stack_pid,
+                bootstrap=self.bootstrap,
+                bootstrap_niter=self.bootstrap_niter,
+            )
+
+            if self.bootstrap:
+                kde_map, kde_errors = kde_histogramdd(**kde_kwargs)
+                kde_errors = np.ascontiguousarray(kde_errors.ravel())
+            else:
+                kde_map = kde_histogramdd(**kde_kwargs)
             kde_map = np.ascontiguousarray(kde_map.ravel())
 
             self.data.representation = self.apply_mode
-            container['weights'] = kde_map
+            container["weights"] = kde_map
+            if self.bootstrap:
+                container["errors"] = kde_errors
+
+            if self.stash_hists:
+                if self.stashed_hists is None:
+                    self.stashed_hists = {}
+                    if self.bootstrap:
+                        self.stashed_errors = {}
+                # Making a copy is required because subsequent stages may change weights
+                # in-place.
+                self.stashed_hists[container.name] = kde_map.copy()
+                if self.bootstrap:
+                    self.stashed_errors[container.name] = kde_errors.copy()
+
+        self.stash_valid = (
+            self.stash_hists
+        )  # valid is true if we are stashing, else not

--- a/pisa/utils/hypersurface/hyper_interpolator.py
+++ b/pisa/utils/hypersurface/hyper_interpolator.py
@@ -51,7 +51,7 @@ class HypersurfaceInterpolator(object):
     After being initialized with a set of hypersurface fits produced at different
     parameters, it uses interpolation to produce a Hypersurface object
     at a given point in parameter space using scipy's `RegularGridInterpolator`.
-    
+
     The interpolation is piecewise-linear between points. All points must lie on a
     rectilinear ND grid.
 
@@ -116,7 +116,7 @@ class HypersurfaceInterpolator(object):
         # The shape of fit_cov_mat is [binning ..., fit coeffts, fit coeffts]
         self.covars_shape = reference_hs.fit_cov_mat.shape
         self.covars = None
-        
+
         # We now need to massage the fit coefficients into the correct shape
         # for interpolation.
         # The dimensions of the interpolation parameters come first, the dimensions
@@ -141,14 +141,14 @@ class HypersurfaceInterpolator(object):
                            for n in self.interp_param_spec.keys()]), msg
             self._coeff_z[idx] = hs_fits[i]["hs_fit"].fit_coeffts
             self._covar_z[idx] = hs_fits[i]["hs_fit"].fit_cov_mat
-        
+
         grid_coords = list(
             np.array([val.m for val in val_list["values"]])
             for val_list in self.interp_param_spec.values()
         )
         self.param_bounds = [(np.min(grid_vals), np.max(grid_vals))
                              for grid_vals in grid_coords]
-        # If a parameter scales as log, we give the log of the parameter to the 
+        # If a parameter scales as log, we give the log of the parameter to the
         # interpolator. We must not forget to do this again when we call the
         # interpolator later!
         for i, param_name in enumerate(self.interpolation_param_names):
@@ -171,11 +171,11 @@ class HypersurfaceInterpolator(object):
         # indeces for which the warning has already been issued.
         self.covar_bins_warning_issued = []
         self.ignore_nan = ignore_nan
-    
+
     @property
     def interpolation_param_names(self):
         return list(self.interp_param_spec.keys())
-    
+
     @property
     def param_names(self):
         return list(self._reference_state["params"].keys())
@@ -190,7 +190,7 @@ class HypersurfaceInterpolator(object):
     @property
     def num_interp_params(self):
         return len(self.interp_param_spec.keys())
-    
+
     def get_hypersurface(self, **param_kw):
         """
         Get a Hypersurface object with interpolated coefficients.
@@ -217,18 +217,18 @@ class HypersurfaceInterpolator(object):
         # if a parameter scales as log, we have to take the log here again
         for i, param_name in enumerate(self.interpolation_param_names):
             if self.interp_param_spec[param_name]["scales_log"]:
-                # We must be strict with raising errors here, because otherwise 
+                # We must be strict with raising errors here, because otherwise
                 # the Hypersurface will suddenly have NaNs everywhere! This shouldn't
                 # happen because we clip values into the valid parameter range.
                 if x[i] <= 0:
                     raise RuntimeError("A log-scaling parameter cannot become zero "
                                        "or negative!")
                 x[i] = np.log10(x[i])
-        
+
         state = copy.deepcopy(self._reference_state)
         # fit covariance matrices are stored directly in the state while fit coeffts
         # must be assigned with the setter method...
-        # need squeeze here because the RegularGridInterpolator always puts another 
+        # need squeeze here because the RegularGridInterpolator always puts another
         # dimension around the output
         state["fit_cov_mat"] = np.squeeze(self.covars(x))
         assert state["fit_cov_mat"].shape == self.covars_shape
@@ -263,7 +263,7 @@ class HypersurfaceInterpolator(object):
         # putting the coefficients in the right place in their respective parameters
         hypersurface.fit_coeffts = coeffts
         return hypersurface
-    
+
     def _make_slices(self, *xi):
         """Make slices of hypersurfaces for plotting.
 
@@ -274,7 +274,7 @@ class HypersurfaceInterpolator(object):
         Parameters
         ----------
         xi : list of ndarray
-            Points at which the hypersurfaces are to be evaluated. The length of the 
+            Points at which the hypersurfaces are to be evaluated. The length of the
             list must equal the number of parameters, each ndarray in the list must have
             the same shape (slice_shape).
 
@@ -318,7 +318,7 @@ class HypersurfaceInterpolator(object):
             n_steps : int, optional
                 number of steps to plot between minimum and maximum
             **param_kw :
-                Parameters to be fixed when producing slices. If the interpolation 
+                Parameters to be fixed when producing slices. If the interpolation
                 is in N-D, then (N-2) parameters need to be fixed to produce 2D plots
                 of the remaining 2 parameters and (N-1) need to be fixed to produce a
                 1D slice.
@@ -339,7 +339,7 @@ class HypersurfaceInterpolator(object):
         # remember whether the plots need log scale or not, by default not
         x_is_log = False
         y_is_log = False
-        
+
         # names of the variables we are plotting
         plot_names = set(self.interpolation_param_names) - set(param_kw.keys())
         if plot_dim == 1:
@@ -367,7 +367,7 @@ class HypersurfaceInterpolator(object):
                 if n == x_name:
                     slice_args.append(x_plot * x_unit)
                 elif n in param_kw.keys():
-                    # again, insure that the same unit is used that went into the 
+                    # again, insure that the same unit is used that went into the
                     # interpolation
                     param_unit = self.interp_param_spec[n]["values"][0].u
                     slice_args.append(
@@ -386,7 +386,7 @@ class HypersurfaceInterpolator(object):
                 y_is_log = True
             else:
                 y_plot = np.linspace(np.min(y_mags), np.max(y_mags), n_steps + 1)
-            
+
             x_mesh, y_mesh = np.meshgrid(x_plot, y_plot)
             slice_args = []
             for n in self.interpolation_param_names:
@@ -395,7 +395,7 @@ class HypersurfaceInterpolator(object):
                 elif n == y_name:
                     slice_args.append(y_mesh * y_unit)
                 elif n in param_kw.keys():
-                    # again, insure that the same unit is used that went into the 
+                    # again, insure that the same unit is used that went into the
                     # interpolation
                     param_unit = self.interp_param_spec[n]["values"][0].u
                     slice_args.append(
@@ -425,7 +425,7 @@ class HypersurfaceInterpolator(object):
                 cbar.ax.ticklabel_format(style='sci', scilimits=(0, 0))
                 ax[i, 0].set_ylabel(y_name)
                 ax[i, 0].set_xlabel(x_name)
-            
+
             # later column plots the elements of the covariance matrix
             for j in range(0, n_coeff):
                 z_slice = covar_slices[bin_idx][i, j]
@@ -443,7 +443,7 @@ class HypersurfaceInterpolator(object):
                     cbar.ax.ticklabel_format(style='sci', scilimits=(0, 0))
                     ax[i, j+1].set_ylabel(y_name)
                     ax[i, j+1].set_xlabel(x_name)
-        
+
         if plot_dim == 1:
             # in the 1D case, labels can be placed on the x and y axes
             for j in range(n_coeff+1):
@@ -471,8 +471,8 @@ class HypersurfaceInterpolator(object):
             ax[i, j].grid()
             if plot_dim == 1:
                 ax[i, j].legend()
-            ax[i, j].relim()
-            ax[i, j].autoscale_view()
+            # ax[i, j].relim()
+            # ax[i, j].autoscale_view()
             if not x_is_log:
                 ax[i, j].ticklabel_format(style='sci', scilimits=(0, 0), axis="x")
             if not y_is_log:
@@ -489,21 +489,21 @@ class HypersurfaceInterpolator(object):
 
 def pipeline_cfg_from_states(state_dict):
     """Recover a pipeline cfg containing PISA objects from a raw state.
-    
-    When a pipeline configuration is stored to JSON, the PISA objects turn into 
+
+    When a pipeline configuration is stored to JSON, the PISA objects turn into
     their serialized states. This function looks through the dictionary returned by
     `from_json` and recovers the PISA objects such as `ParamSet` and `MultiDimBinning`.
-        
+
     It should really become part of PISA file I/O functionality to read and write
     PISA objects inside dictionaries/lists into a JSON and be able to recover
     them...
     """
-    
+
     # TODO: Make this a core functionality of PISA
-    
+
     # This is just a mess... some objects have a `from_state` method, some take the
     # unpacked state dict as input, some take the state...
-    
+
     pipeline_cfg = collections.OrderedDict()
     for stage_key in state_dict.keys():
         # need to check all of this manually... no automatic way to do it :(
@@ -531,7 +531,7 @@ def pipeline_cfg_from_states(state_dict):
 
 def serialize_pipeline_cfg(pipeline_cfg):
     """Turn a pipeline configuration into something we can store to JSON.
-    
+
     It doesn't work by default because tuples are not allowed as keys when storing to
     JSON. All we do is to turn the tuples into strings divided by a double underscore.
     """
@@ -544,17 +544,17 @@ def serialize_pipeline_cfg(pipeline_cfg):
     # this isn't _really_ a serializable state, the objects are still PISA objects...
     # bit it will convert correctly when thrown into `to_json`
     return serializable_state
-    
-    
+
+
 def assemble_interpolated_fits(fit_directory, output_file, drop_fit_maps=False):
     """After all of the fits on the cluster are done, assemble the results to one JSON.
-    
+
     The JSON produced by this function is what `load_interpolated_hypersurfaces`
     expects.
     """
     assert os.path.isdir(fit_directory), "fit directory does not exist"
     metadata = from_json(os.path.join(fit_directory, "metadata.json"))
-    
+
     combined_data = collections.OrderedDict()
     combined_data["interpolation_param_spec"] = metadata["interpolation_param_spec"]
 
@@ -593,7 +593,7 @@ def assemble_interpolated_fits(fit_directory, output_file, drop_fit_maps=False):
 
 def get_incomplete_job_idx(fit_directory):
     """Get job indices of fits that are not flagged as successful."""
-    
+
     assert os.path.isdir(fit_directory), "fit directory does not exist"
     metadata = from_json(os.path.join(fit_directory, "metadata.json"))
     grid_shape = tuple(metadata["grid_shape"])
@@ -613,16 +613,16 @@ def get_incomplete_job_idx(fit_directory):
 
 def run_interpolated_fit(fit_directory, job_idx, skip_successful=False):
     """Run the hypersurface fit for a grid point.
-    
+
     If `skip_successful` is true, do not run if the `fit_successful` flag is already
     True.
     """
 
     #TODO a lot of this is copied from fit_hypersurfaces in hypersurface.py, would be safer to make more OAOO
     #TODO Copy the param value storage stuff from fit_hypersurfaces across in the meantime
-    
+
     assert os.path.isdir(fit_directory), "fit directory does not exist"
-    
+
     gridpoint_json = os.path.join(fit_directory, f"gridpoint_{job_idx:06d}.json.bz2")
     gridpoint_data = from_json(gridpoint_json)
 
@@ -631,9 +631,9 @@ def run_interpolated_fit(fit_directory, job_idx, skip_successful=False):
         return
 
     metadata = from_json(os.path.join(fit_directory, "metadata.json"))
-    
+
     interpolation_param_spec = metadata["interpolation_param_spec"]
-    
+
     # this is a pipeline configuration in the form of an OrderedDict
     nominal_dataset = metadata["nominal_dataset"]
     # Why can we still not load PISA objects from JSON that are inside a dict?! Grrr...
@@ -657,7 +657,7 @@ def run_interpolated_fit(fit_directory, job_idx, skip_successful=False):
     for i, n in enumerate(interpolation_param_names):
         ms = "Inconsistent parameter values at grid point!"
         assert interpolation_param_spec[n]["values"][grid_idx[i]] == param_values[n], ms
-    
+
     # now we need to adjust the values of the parameter in all pipelines for this point
     logging.info(f"updating pipelines with parameter values: {param_values}")
     for dataset in [nominal_dataset] + sys_datasets:
@@ -666,27 +666,55 @@ def run_interpolated_fit(fit_directory, job_idx, skip_successful=False):
             for param in interpolation_param_names:
                 if param in stage_cfg["params"].names:
                     stage_cfg["params"][param].value = param_values[param]
-    
+
     # these are the parameters of the hypersurface, NOT the ones we interpolate them
     # over!
     hypersurface_params = []
     for param_state in metadata["hypersurface_params"]:
         hypersurface_params.append(HypersurfaceParam.from_state(param_state))
 
+    def find_hist_stage(pipeline):
+        """Locate the index of the hist stage in a pipeline."""
+        hist_idx_found = False
+        for i, s in enumerate(pipeline.stages):
+            if s.__class__.__name__ == "hist":
+                hist_idx = i
+                hist_idx_found = True
+                break
+        if not hist_idx_found:
+            raise RuntimeError("Could not find histogram stage in pipeline, aborting.")
+        return hist_idx
+
     # We create Pipeline objects, get their outputs and then forget about the Pipeline
     # object on purpose! The memory requirement to hold all systematic sets at the same
     # time is just too large, especially on the cluster. The way we do it below we
     # only need enough memory for one dataset at a time.
-    nominal_dataset["mapset"] = Pipeline(nominal_dataset["pipeline_cfg"]).get_outputs()
-    for sys_dataset in sys_datasets:
-        sys_dataset["mapset"] = Pipeline(sys_dataset["pipeline_cfg"]).get_outputs()
-    
+
+    for dataset in [nominal_dataset] + sys_datasets:
+        pipeline = Pipeline(dataset["pipeline_cfg"])
+        dataset["mapset"] = pipeline.get_outputs()
+        # get the un-weighted event counts as well so that we can exclude bins
+        # with too little statistics
+        # First, find out which stage is the hist stage
+        hist_idx = find_hist_stage(pipeline)
+        pipeline.stages[hist_idx].unweighted = True
+        dataset["mapset_unweighted"] = pipeline.get_outputs()
+    del pipeline
+
     # Merge maps according to the combine regex, if one was provided
     combine_regex = metadata["combine_regex"]
     if combine_regex is not None:
-        nominal_dataset["mapset"] = nominal_dataset["mapset"].combine_re(combine_regex)
-        for sys_dataset in sys_datasets:
-            sys_dataset["mapset"] = sys_dataset["mapset"].combine_re(combine_regex)
+        for dataset in [nominal_dataset] + sys_datasets:
+            dataset["mapset"] = dataset["mapset"].combine_re(combine_regex)
+            dataset["mapset_unweighted"] = dataset["mapset_unweighted"].combine_re(combine_regex)
+
+    minimum_mc = metadata["minimum_mc"]
+    # Remove bins (i.e. set their count to zero) that have too few MC events
+    for dataset in sys_datasets + [nominal_dataset]:
+        for map_name in dataset["mapset"].names:
+            insuff_mc = dataset["mapset_unweighted"][map_name].nominal_values < minimum_mc
+            # Setting the hist to zero sets both nominal value and std_dev to zero
+            dataset["mapset"][map_name].hist[insuff_mc] = 0.
 
     hypersurface_fit_kw = metadata["hypersurface_fit_kw"]
     hypersurfaces = collections.OrderedDict()
@@ -722,13 +750,13 @@ def run_interpolated_fit(fit_directory, job_idx, skip_successful=False):
 
     gridpoint_data["hs_fit"] = hypersurfaces
     gridpoint_data["fit_successful"] = True
-    
+
     to_json(gridpoint_data, gridpoint_json)
 
 
 def prepare_interpolated_fit(
     nominal_dataset, sys_datasets, params, fit_directory, interpolation_param_spec,
-    combine_regex=None, log=False, **hypersurface_fit_kw
+    combine_regex=None, log=False, minimum_mc=0, **hypersurface_fit_kw
 ):
     '''
     Writes steering files for fitting hypersurfaces on a grid of arbitrary parameters.
@@ -766,7 +794,7 @@ def prepare_interpolated_fit(
         combine similar species. Must be something that can be passed to the
         `MapSet.combine_re` function (see that functions docs for more details). Choose
         `None` is do not want to perform this merging.
-    
+
     interpolation_param_spec : collections.OrderedDict
         Specification of parameter grid that hypersurfaces should be interpolated over.
         The dict should have the following form::
@@ -779,6 +807,9 @@ def prepare_interpolated_fit(
         The hypersurfaces will be fit on an N-dimensional rectilinear grid over
         parameters 1 to N. The flag `scales_log` indicates that the interpolation over
         that parameter should happen in log-space.
+
+    minimum_mc : int, optional
+        Minimum number of un-weighted MC events required in each bin.
 
     hypersurface_fit_kw : kwargs
         kwargs will be passed on to the calls to `Hypersurface.fit`
@@ -794,7 +825,7 @@ def prepare_interpolated_fit(
     assert isinstance(sys_datasets, collections.Sequence)
     assert isinstance(params, collections.Sequence)
     assert isinstance(fit_directory, str)
-    # there must not be any ambiguity between fitting the hypersurfaces and 
+    # there must not be any ambiguity between fitting the hypersurfaces and
     # interpolating them later
     msg = "interpolation params must be specified as a dict with ordered keys"
     assert isinstance(interpolation_param_spec, collections.OrderedDict), msg
@@ -810,10 +841,10 @@ def prepare_interpolated_fit(
         if v["scales_log"] and np.min(mags) <= 0:
             raise ValueError("A log-scaling parameter cannot be equal to or less "
                 "than zero!")
-    
+
     # Check output format and path
     assert os.path.isdir(fit_directory), "fit directory does not exist"
-    
+
     # Check formatting of datasets is as expected
     all_datasets = [nominal_dataset] + sys_datasets
     for dataset in all_datasets:
@@ -822,7 +853,7 @@ def prepare_interpolated_fit(
         assert isinstance(dataset["pipeline_cfg"], (str, collections.Mapping))
         assert "sys_params" in dataset
         assert isinstance(dataset["sys_params"], collections.Mapping)
-        
+
         dataset["pipeline_cfg"] = serialize_pipeline_cfg(dataset["pipeline_cfg"])
 
     # Check params
@@ -855,11 +886,12 @@ def prepare_interpolated_fit(
         hypersurface_params=params,
         combine_regex=combine_regex,
         log=log,
+        minimum_mc=minimum_mc,
         hypersurface_fit_kw=hypersurface_fit_kw
     )
-    
+
     to_json(metadata, os.path.join(fit_directory, "metadata.json"))
-    
+
     # we write on JSON file for each grid point
     for job_idx, grid_idx in enumerate(np.ndindex(grid_shape)):
         # Although this is technically redundant, we store the parameter values
@@ -940,7 +972,7 @@ def load_interpolated_hypersurfaces(input_file):
             hs_state_maps[map_name] = Hypersurface.from_state(hs_state_maps[map_name])
 
     logging.info(f"Read hypersurface maps: {map_names}")
-    
+
     # Now we have a list of dicts where the map names are on the lower level.
     # We need to convert this into a dict of HypersurfaceInterpolator objects.
     output = collections.OrderedDict()

--- a/pisa/utils/hypersurface/hypersurface_plotting.py
+++ b/pisa/utils/hypersurface/hypersurface_plotting.py
@@ -19,7 +19,7 @@ __license__ = '''Copyright (c) 2014-2017, The IceCube Collaboration
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.'''
- 
+
 import numpy as np
 
 def plot_bin_fits(ax, hypersurface, bin_idx, param_name, color=None, label=None, show_nominal=False, show_offaxis=True, show_zero=False, show_uncertainty=True):
@@ -139,6 +139,7 @@ def plot_bin_fits(ax, hypersurface, bin_idx, param_name, color=None, label=None,
     ax.set_xlabel(param.name)
     ax.grid(True)
     ax.legend()
+    ax.set_ylim((-0.1, 4))
 
 
 def plot_bin_fits_2d(ax, hypersurface, bin_idx, param_names):

--- a/pisa/utils/kde_hist.py
+++ b/pisa/utils/kde_hist.py
@@ -5,7 +5,7 @@ Functions to get KDE smoothed historgams
 
 from __future__ import absolute_import, division
 
-from kde.cudakde import gaussian_kde
+from kde.cudakde import gaussian_kde, bootstrap_kde
 import numpy as np
 from uncertainties import unumpy as unp
 import copy
@@ -13,11 +13,11 @@ import copy
 from pisa.core.binning import OneDimBinning, MultiDimBinning
 
 
-__all__ = ['get_hist', 'kde_histogramdd', 'test_kde_histogramdd']
+__all__ = ["get_hist", "kde_histogramdd", "test_kde_histogramdd"]
 
-__author__ = 'P. Eller'
+__author__ = "P. Eller"
 
-__license__ = '''Copyright (c) 2014-2017, The IceCube Collaboration
+__license__ = """Copyright (c) 2014-2017, The IceCube Collaboration
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,16 +29,27 @@ __license__ = '''Copyright (c) 2014-2017, The IceCube Collaboration
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License.'''
+ limitations under the License."""
 
 
-def get_hist(sample, binning, weights=None, bw_method='scott', adaptive=True,
-             alpha=0.3, use_cuda=False, coszen_reflection=0.25,
-             coszen_name='coszen', oversample=1):
+def get_hist(
+    sample,
+    binning,
+    weights=None,
+    bw_method="scott",
+    adaptive=True,
+    alpha=0.3,
+    use_cuda=False,
+    coszen_reflection=0.25,
+    coszen_name="coszen",
+    oversample=1,
+    bootstrap=False,
+    bootstrap_niter=10,
+):
     """Helper function for histograms from KDE
 
     For description of args see kde_histogramdd()
-     
+
     Handling the reflctions at the coszen edges
 
     ToDo:
@@ -52,6 +63,11 @@ def get_hist(sample, binning, weights=None, bw_method='scott', adaptive=True,
     * Any good reason for 0.25 and 'scott' defaults? If not, don't define a
       default and force the user to explicitly set this when function is called.
     """
+
+    if bootstrap and oversample > 1:
+        # Because the errors within a bin are highly correlated, they could not just
+        # be added in quadrature to create an oversampled histogram with errors.
+        raise ValueError("Bootstrapping cannot be combined with oversampling.")
 
     # the KDE implementation expects an empty weights array instead of `None`
     if weights is None:
@@ -91,10 +107,18 @@ def get_hist(sample, binning, weights=None, bw_method='scott', adaptive=True,
     reflect_upper = binning[coszen_name].bin_edges[-1] == 1
 
     # Get the kernel weights
-    kernel_weights_adaptive = gaussian_kde(
-        x, weights=weights, bw_method=bw_method, adaptive=adaptive,
-        alpha=alpha, use_cuda=use_cuda
+
+    kde_kwargs = dict(
+        weights=weights,
+        bw_method=bw_method,
+        adaptive=adaptive,
+        alpha=alpha,
+        use_cuda=use_cuda,
     )
+    if bootstrap:
+        kernel_weights_adaptive = bootstrap_kde(x, niter=bootstrap_niter, **kde_kwargs)
+    else:
+        kernel_weights_adaptive = gaussian_kde(x, **kde_kwargs)
 
     # Get the bin centers, where we're going to evaluate the KDEs, and extend
     # the bin range for reflection
@@ -103,13 +127,13 @@ def get_hist(sample, binning, weights=None, bw_method='scott', adaptive=True,
         c = unp.nominal_values(b.weighted_centers)
         if b.name == coszen_name:
             # how many bins to add for reflection
-            l = int(len(c)*coszen_reflection)
+            l = int(len(c) * coszen_reflection)
             if reflect_lower:
-                c0 = 2*c[0] - c[1:l+1][::-1]
+                c0 = 2 * c[0] - c[1 : l + 1][::-1]
             else:
                 c0 = []
             if reflect_upper:
-                c1 = 2*c[-1] - c[-l-1:-1][::-1]
+                c1 = 2 * c[-1] - c[-l - 1 : -1][::-1]
             else:
                 c1 = []
             c = np.concatenate([c0, c, c1])
@@ -117,66 +141,98 @@ def get_hist(sample, binning, weights=None, bw_method='scott', adaptive=True,
 
     # Shape including reflection edges
     megashape = (
-        binning.shape[0] + (int(reflect_upper)+int(reflect_lower))*l,
-        binning.shape[1]
+        binning.shape[0] + (int(reflect_upper) + int(reflect_lower)) * l,
+        binning.shape[1],
     )
 
     # Shape of the reflection edges alone
     minishape = (binning.shape[0] - l, binning.shape[1])
 
     # Create a set of points
-    grid = np.meshgrid(*bin_points, indexing='ij')
+    grid = np.meshgrid(*bin_points, indexing="ij")
     points = np.array([g.ravel() for g in grid])
 
     # Evaluate KDEs at given points
-    hist = kernel_weights_adaptive(points)
+    if bootstrap:
+        hist, errors = kernel_weights_adaptive(points)
+        # variances can simply be added together when we apply reflections, we take
+        # the root afterwards
+        variances = errors ** 2
+    else:
+        hist = kernel_weights_adaptive(points)
 
     # Reshape 1d array into nd
     hist = hist.reshape(megashape)
+    if bootstrap:
+        variances = variances.reshape(megashape)
 
-    # Cut off the reflection edges, mirror them, fill up remaining space with
-    # zeros and add to histo
-    if reflect_lower:
-        hist0 = hist[0:l, :]
-        hist0_0 = np.zeros(minishape)
-        hist0 = np.flipud(np.concatenate([hist0_0, hist0]))
-        hist = hist[l:, :]
-    else:
-        hist0 = 0
+    def apply_reflection(hist_):
+        # Cut off the reflection edges, mirror them, fill up remaining space with
+        # zeros and add to histo
+        if reflect_lower:
+            hist0 = hist_[0:l, :]
+            hist0_0 = np.zeros(minishape)
+            hist0 = np.flipud(np.concatenate([hist0_0, hist0]))
+            hist_ = hist_[l:, :]
+        else:
+            hist0 = 0
 
-    if reflect_upper:
-        hist1 = hist[-l:, :]
-        hist1_0 = np.zeros(minishape)
-        hist1 = np.flipud(np.concatenate([hist1, hist1_0]))
-        hist = hist[:-l, :]
-    else:
-        hist1 = 0
+        if reflect_upper:
+            hist1 = hist_[-l:, :]
+            hist1_0 = np.zeros(minishape)
+            hist1 = np.flipud(np.concatenate([hist1, hist1_0]))
+            hist_ = hist_[:-l, :]
+        else:
+            hist1 = 0
 
-    hist = hist + hist1 + hist0
+        hist_ = hist_ + hist1 + hist0
+        return hist_
+
+    hist = apply_reflection(hist)
+    if bootstrap:
+        variances = apply_reflection(variances)
+        errors = np.sqrt(variances)
 
     # Bin volumes
     volume = binning.bin_volumes(attach_units=False)
-    hist = hist*volume
+    hist = hist * volume
+    if bootstrap:
+        errors = errors * volume
 
-    # Downsample
+    # Downsample, not applicable when bootstrapping
     if oversample != 1:
         for i, b in enumerate(binning):
             hist = np.add.reduceat(
-                hist,
-                np.arange(0, len(b.bin_edges)-1, oversample),
-                axis=i
+                hist, np.arange(0, len(b.bin_edges) - 1, oversample), axis=i
             )
 
     # Swap back the axes
     if cz_bin != 0:
         hist = np.swapaxes(hist, 0, cz_bin)
+        if bootstrap:
+            errors = np.swapaxes(errors, 0, cz_bin)
 
-    return hist*norm
+    if bootstrap:
+        return hist * norm, errors * norm
+    else:
+        return hist * norm
 
-def kde_histogramdd(sample, binning, weights=None, bw_method='scott',
-                    adaptive=True, alpha=0.3, use_cuda=False,
-                    coszen_reflection=0.25, coszen_name='coszen', oversample=1,
-                    stack_pid=True):
+
+def kde_histogramdd(
+    sample,
+    binning,
+    weights=None,
+    bw_method="scott",
+    adaptive=True,
+    alpha=0.3,
+    use_cuda=False,
+    coszen_reflection=0.25,
+    coszen_name="coszen",
+    oversample=1,
+    stack_pid=True,
+    bootstrap=False,
+    bootstrap_niter=10
+):
     """Run kernel density estimation (KDE) for an array of data points, and
     then evaluate them on a histogram-like grid to effectively produce a
     histogram-like output.
@@ -224,6 +280,13 @@ def kde_histogramdd(sample, binning, weights=None, bw_method='scott',
         Treat each pid bin separately, not as another dimension of the KDEs
         Only supported for two additional dimensions, pid binning must be named `pid`
 
+    bootstrap : bool
+        Use the ``bootstrap_kde`` class to produce error estimates on the KDE histograms.
+        Slow, not recommended during fits.
+
+    bootstrap_niter : int
+        Number of bootstrap iterations.
+
     Returns
     -------
     histogram : numpy.ndarray
@@ -236,8 +299,10 @@ def kde_histogramdd(sample, binning, weights=None, bw_method='scott',
 
     """
     if weights is not None and len(weights) != sample.shape[0]:
-        raise ValueError('Length of sample (%s) and weights (%s) incompatible'
-                         %(sample.shape[0], len(weights)))
+        raise ValueError(
+            "Length of sample (%s) and weights (%s) incompatible"
+            % (sample.shape[0], len(weights))
+        )
 
     if not stack_pid:
         return get_hist(
@@ -250,14 +315,16 @@ def kde_histogramdd(sample, binning, weights=None, bw_method='scott',
             use_cuda=use_cuda,
             coszen_reflection=coszen_reflection,
             coszen_name=coszen_name,
-            oversample=oversample
+            oversample=oversample,
+            bootstrap=bootstrap,
+            bootstrap_niter=bootstrap_niter
         )
 
     # treat pid bins separately
     # asuming we're dealing with 2d apart from PID
     bin_names = copy.copy(binning.names)
     bin_edges = [b.bin_edges.m for b in binning]
-    pid_bin = bin_names.index('pid')
+    pid_bin = bin_names.index("pid")
     other_bins = [0, 1, 2]
     other_bins.pop(pid_bin)
     bin_names.pop(pid_bin)
@@ -265,49 +332,67 @@ def kde_histogramdd(sample, binning, weights=None, bw_method='scott',
     pid_bin_edges = bin_edges.pop(pid_bin)
     d2d_binning = []
     for b in binning:
-        if b.name != 'pid':
+        if b.name != "pid":
             d2d_binning.append(b)
     d2d_binning = MultiDimBinning(d2d_binning)
     pid_stack = []
-    for pid in range(len(pid_bin_edges)-1):
-        mask_pid = (
-            (sample.T[pid_bin] >= pid_bin_edges[pid])
-            & (sample.T[pid_bin] < pid_bin_edges[pid+1])
+    if bootstrap:
+        pid_stack_errors = []
+
+    for pid in range(len(pid_bin_edges) - 1):
+        mask_pid = (sample.T[pid_bin] >= pid_bin_edges[pid]) & (
+            sample.T[pid_bin] < pid_bin_edges[pid + 1]
         )
-        data = np.array([
-            sample.T[other_bins[0]][mask_pid],
-            sample.T[other_bins[1]][mask_pid]
-        ])
+        data = np.array(
+            [sample.T[other_bins[0]][mask_pid], sample.T[other_bins[1]][mask_pid]]
+        )
 
         if weights is None:
             weights_pid = None
         else:
             weights_pid = weights[mask_pid]
 
-        pid_stack.append(
-            get_hist(
-                sample=data.T,
-                weights=weights_pid,
-                binning=d2d_binning,
-                coszen_name=coszen_name,
-                use_cuda=use_cuda,
-                bw_method=bw_method,
-                alpha=alpha,
-                oversample=oversample,
-                coszen_reflection=coszen_reflection,
-                adaptive=adaptive
-            )
+        hist_kwargs = dict(
+            sample=data.T,
+            weights=weights_pid,
+            binning=d2d_binning,
+            coszen_name=coszen_name,
+            use_cuda=use_cuda,
+            bw_method=bw_method,
+            alpha=alpha,
+            oversample=oversample,
+            coszen_reflection=coszen_reflection,
+            adaptive=adaptive,
+            bootstrap=bootstrap,
+            bootstrap_niter=bootstrap_niter
         )
+        if bootstrap:
+            hist, errors = get_hist(**hist_kwargs)
+            pid_stack.append(hist)
+            pid_stack_errors.append(errors)
+        else:
+            pid_stack.append(get_hist(**hist_kwargs))
+
     hist = np.dstack(pid_stack)
+    if bootstrap:
+        errors = np.dstack(pid_stack_errors)
+
     if pid_bin != 2:
         hist = np.swapaxes(hist, pid_bin, 2)
-    return hist
+        if bootstrap:
+            errors = np.swapaxes(errors, pid_bin, 2)
+
+    if bootstrap:
+        return hist, errors
+    else:
+        return hist
 
 
 # TODO: make the plotting optional but add comparisons against some known
 # results. This can be accomplished by seeding before calling random to obtain
 # a reference result, and check that the same values are returned when run
 # below.
+
 
 def test_kde_histogramdd():
     """Unit tests for kde_histogramdd"""
@@ -320,23 +405,30 @@ def test_kde_histogramdd():
     from pisa.utils.plotter import Plotter
 
     parser = ArgumentParser()
-    parser.add_argument('-v', action='count', default=None,
-                        help='set verbosity level')
+    parser.add_argument("-v", action="count", default=None, help="set verbosity level")
     args = parser.parse_args()
     set_verbosity(args.v)
 
     temp_dir = mkdtemp()
 
     try:
-        my_plotter = Plotter(stamp='', outdir=temp_dir, fmt='pdf', log=False,
-                             annotate=False, symmetric=False, ratio=True)
+        my_plotter = Plotter(
+            stamp="",
+            outdir=temp_dir,
+            fmt="pdf",
+            log=False,
+            annotate=False,
+            symmetric=False,
+            ratio=True,
+        )
 
-        b1 = OneDimBinning(name='coszen', num_bins=20, is_lin=True,
-                           domain=[-1, 1], tex=r'\cos(\theta)')
-        b2 = OneDimBinning(name='energy', num_bins=10, is_log=True,
-                           domain=[1, 80]*ureg.GeV, tex=r'E')
-        b3 = OneDimBinning(name='pid', num_bins=2,
-                           bin_edges=[0, 1, 2], tex=r'pid')
+        b1 = OneDimBinning(
+            name="coszen", num_bins=20, is_lin=True, domain=[-1, 1], tex=r"\cos(\theta)"
+        )
+        b2 = OneDimBinning(
+            name="energy", num_bins=10, is_log=True, domain=[1, 80] * ureg.GeV, tex=r"E"
+        )
+        b3 = OneDimBinning(name="pid", num_bins=2, bin_edges=[0, 1, 2], tex=r"pid")
         binning = b1 * b2 * b3
 
         # now let's generate some toy data
@@ -354,31 +446,36 @@ def test_kde_histogramdd():
         raw_hist, _ = np.histogramdd(data, bins=bins)
 
         # get KDE'ed histo
-        hist = kde_histogramdd(data, binning, bw_method='silverman',
-                               coszen_name='coszen', oversample=10,
-                               use_cuda=True,
-                               stack_pid=True)
+        hist = kde_histogramdd(
+            data,
+            binning,
+            bw_method="silverman",
+            coszen_name="coszen",
+            oversample=10,
+            use_cuda=True,
+            stack_pid=True,
+        )
 
         # put into mapsets and plot
-        m1 = Map(name='KDE', hist=hist, binning=binning)
-        m2 = Map(name='raw', hist=raw_hist, binning=binning)
-        with np.errstate(divide='ignore', invalid='ignore'):
-            m3 = m2/m1
-        m3.name = 'hist/KDE'
+        m1 = Map(name="KDE", hist=hist, binning=binning)
+        m2 = Map(name="raw", hist=raw_hist, binning=binning)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            m3 = m2 / m1
+        m3.name = "hist/KDE"
         m3.tex = m3.name
         m4 = m1 - m2
-        m4.name = 'KDE - hist'
+        m4.name = "KDE - hist"
         m4.tex = m4.name
         ms = MapSet([m1, m2, m3, m4])
-        my_plotter.plot_2d_array(ms, fname='test_kde', cmap='summer')
+        my_plotter.plot_2d_array(ms, fname="test_kde", cmap="summer")
     except:
         rmtree(temp_dir)
         raise
     else:
         logging.warning(
-            'Inspect and manually clean up output(s) saved to %s' % temp_dir
+            "Inspect and manually clean up output(s) saved to %s" % temp_dir
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_kde_histogramdd()


### PR DESCRIPTION
This PR adds the option to estimate errors on KDE'd histograms using the ``bootstrap_kde`` class from the KDE module that we already used. It's of course very slow and not recommended to be used in a fit, but it is very useful for fitting hyper surfaces with statistically sound errors. Other changes are:

* To the ``aeff.weight`` stage:
  * Scale errors along with weights in the ``aeff.weight`` stage
    * This makes it possible to do the weighting _after_ making histograms in a pipeline. In this way, KDE histograms have to be calculated only once before a fit starts, and the histograms are simply scaled with the efficiency.
* to the ``utils.kde`` stage:
  * Add option to stash histograms in the KDE stage. Ties into the point above: the (expensive) KDEs only need to be done once before a fit.
  * Calculate KDEs in log-space for variables that are binned logarithmically (i.e. energy). Significantly decreases distortions in the energy dimension.
* to the ``utils.hist`` stage:
  * Add option to calculate unweighted histograms. Makes it possible to look at raw MC counts, which is useful for diagnostics. Can be used to exclude points with a very small number of MC events from Hypersurface fits, where the Gaussian assumption would be badly broken.
* to hyper surface code:
  * Add option to exclude data points with too little MC or weighted count from the fits.
  * Support Pipelines that use KDEs to produce histograms as long as they use bootstrapping.
  * Plot bin-wise fits on fixed range. Should probably be an option rather than being hard-coded...
* Ran the KDE code through ``black`` to make it nicer.