### PR TITLE
Fixing map saving.

### DIFF
--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -849,7 +849,7 @@ class Map(object):
         if fmt is not None:
             for fmt_ in fmt:
                 path = os.path.join(outdir, fname + '.' + fmt_)
-                fig.savefig(os.path.join(*path))
+                fig.savefig(path)
                 logging.debug('>>>> Plot for inspection saved at %s', path)
 
         return fig, ax, pcmesh, colorbar


### PR DESCRIPTION
The additional `os.path.join` chopped up the filename and broke the saving. Maybe I'm missing something here, but I don't see it being necessary let alone working on my end.