### PR TITLE
Make CRS2 fits reproducible

### DIFF
--- a/pisa/core/map.py
+++ b/pisa/core/map.py
@@ -3096,7 +3096,29 @@ def test_Map():
     m_rebinned = m1.rebin(m1.binning.downsample(n_ebins, n_czbins))
     assert m_rebinned.hist[0, 0] == np.sum(m1.hist)
 
-
+    # Test fluctuate
+    _ = m1.fluctuate(method="poisson")  # just ensure that None random_state is handled
+    m1_seed0 = m1.fluctuate(method="poisson", random_state=0)
+    m1_seed1 = m1.fluctuate(method="poisson", random_state=1)
+    m1_seed0_reprod = m1.fluctuate(method="poisson", random_state=0)
+    for m in [m1_seed0, m1_seed1, m1_seed0_reprod]:
+        # The full comparison has to be ON for all maps, otherwise we would only
+        # compare the hash value, which doesn't change when maps are fluctuated.
+        # Because the value of full_comparison is included in the comparison, two 
+        # maps will not be considered equal if only one of them has
+        # `full_comparison=True`.
+        # TODO: How does this make sense?
+        m.full_comparison = True
+    logging.debug("Fluctuated map with seed 0:")
+    logging.debug(m1_seed0)
+    logging.debug("Fluctuated map with seed 1:")
+    logging.debug(m1_seed1)
+    logging.debug("Fluctuated map with seed 0, reproduced:")
+    logging.debug(m1_seed0_reprod)
+    
+    assert m1_seed0 == m1_seed0_reprod
+    assert not (m1_seed0 == m1_seed1)
+    
     # Test sum()
     m1 = Map(
         name='x',
@@ -3256,7 +3278,22 @@ def test_MapSet():
     m2 = Map(name='twos', hist=2*np.ones(binning.shape), binning=binning,
              hash='xyz')
     ms01 = MapSet([m1, m2])
+    
+    # Test fluctuate
+    _ = ms01.fluctuate(method="poisson")  # just ensure that None random_state is handled
+    ms01_seed0 = ms01.fluctuate(method="poisson", random_state=0)
+    ms01_seed1 = ms01.fluctuate(method="poisson", random_state=1)
+    ms01_seed0_reprod = ms01.fluctuate(method="poisson", random_state=0)
+    logging.debug("Fluctuated map set with seed 0:")
+    logging.debug(ms01_seed0)
+    logging.debug("Fluctuated map set with seed 1:")
+    logging.debug(ms01_seed1)
+    logging.debug("Fluctuated map set with seed 0, reproduced:")
+    logging.debug(ms01_seed0_reprod)
 
+    assert ms01_seed0 == ms01_seed0_reprod
+    assert not (ms01_seed0 == ms01_seed1)
+    
     # Test rebin
     _ = ms01.rebin(m1.binning.downsample(3))
     ms01_rebinned = ms01.rebin(m1.binning.downsample(6, 3))

--- a/pisa/utils/random_numbers.py
+++ b/pisa/utils/random_numbers.py
@@ -82,8 +82,7 @@ def get_random_state(random_state, jumpahead=0):
 
     """
     if random_state is None:
-        # FIXME: not a `numpy.random.RandomState` object
-        new_random_state = np.random
+        new_random_state = np.random.RandomState()
 
     elif isinstance(random_state, np.random.RandomState):
         new_random_state = random_state


### PR DESCRIPTION
This PR makes fits with CRS2 (or any other NLOPT algorithm with a random component) reproducible if a seed is passed to `method_kwargs`, and adds a unit test to assert that this behaves correctly. It also adds unit tests to fluctuate `Map` and `MapSet` objects and fixes an issue where `get_random_state` without a random state would crash. 