### PR TITLE
Make KDE bootstrap reproducible

### DIFF
--- a/pisa/stages/utils/kde.py
+++ b/pisa/stages/utils/kde.py
@@ -54,7 +54,7 @@ class kde(Stage):
         stash_hists=False,
         bootstrap=False,
         bootstrap_niter=10,
-        bootstrap_seed=0,
+        bootstrap_seed=None,
         **std_kargs,
     ):
 
@@ -66,8 +66,11 @@ class kde(Stage):
         self.stash_hists = stash_hists
         self.stash_valid = False
         self.bootstrap = bootstrap
-        self.bootstrap_niter = bootstrap_niter
-        self.bootstrap_seed = bootstrap_seed
+        self.bootstrap_niter = int(bootstrap_niter)
+        if bootstrap_seed is not None:
+            self.bootstrap_seed = int(bootstrap_seed)
+        else:
+            self.bootstrap_seed = None
 
         if stash_hists:
             self.stashed_hists = None

--- a/pisa/stages/utils/kde.py
+++ b/pisa/stages/utils/kde.py
@@ -4,6 +4,7 @@ that represent event counts
 """
 import numpy as np
 
+
 from copy import deepcopy
 from pisa import FTYPE, TARGET
 from pisa.core.stage import Stage
@@ -11,7 +12,7 @@ from pisa.core.binning import MultiDimBinning, OneDimBinning
 from pisa.utils.log import logging
 from pisa.utils.profiler import profile
 from pisa.utils import vectorizer
-from pisa.utils.kde_hist import kde_histogramdd
+from pisa.utils import kde_hist
 
 
 class kde(Stage):
@@ -53,6 +54,7 @@ class kde(Stage):
         stash_hists=False,
         bootstrap=False,
         bootstrap_niter=10,
+        bootstrap_seed=0,
         **std_kargs,
     ):
 
@@ -65,6 +67,7 @@ class kde(Stage):
         self.stash_valid = False
         self.bootstrap = bootstrap
         self.bootstrap_niter = bootstrap_niter
+        self.bootstrap_seed = bootstrap_seed
 
         if stash_hists:
             self.stashed_hists = None
@@ -82,9 +85,9 @@ class kde(Stage):
 
     def setup_function(self):
 
-        assert isinstance(self.apply_mode, MultiDimBinning), (
-            f"KDE stage needs a binning as `apply_mode`, but is {self.apply_mode}"
-        )
+        assert isinstance(
+            self.apply_mode, MultiDimBinning
+        ), f"KDE stage needs a binning as `apply_mode`, but is {self.apply_mode}"
 
         # For dimensions that are logarithmic, we add a linear binning in
         # the logarithm.
@@ -103,14 +106,14 @@ class kde(Stage):
                 )
             else:
                 new_dim = OneDimBinning(
-                    dim.name,
-                    domain=np.log(dim.domain.m),
-                    num_bins=dim.num_bins
+                    dim.name, domain=np.log(dim.domain.m), num_bins=dim.num_bins
                 )
             dimensions.append(new_dim)
 
             self.regularized_apply_mode = MultiDimBinning(dimensions)
-            logging.debug("Using regularized binning:\n" + repr(self.regularized_apply_mode))
+            logging.debug(
+                "Using regularized binning:\n" + repr(self.regularized_apply_mode)
+            )
 
     @profile
     def apply(self):
@@ -140,28 +143,100 @@ class kde(Stage):
                     container.representation = "events"
                     sample.append(container[dim.name])
 
+            # Make sure that we revert back to "events" before extracting weights (could
+            # otherwise end up in "log_events").
+            container.representation = "events"
+
             sample = np.stack(sample).T
             weights = container["weights"]
 
             kde_kwargs = dict(
                 sample=sample,
                 binning=self.regularized_apply_mode,
-                weights=weights,
+                # weights=weights,
                 bw_method=self.bw_method,
                 coszen_name=self.coszen_name,
                 coszen_reflection=self.coszen_reflection,
                 oversample=self.oversample,
                 use_cuda=False,
                 stack_pid=self.stack_pid,
-                bootstrap=self.bootstrap,
-                bootstrap_niter=self.bootstrap_niter,
+                # bootstrap=self.bootstrap,
+                # bootstrap_niter=self.bootstrap_niter,
             )
 
             if self.bootstrap:
-                kde_map, kde_errors = kde_histogramdd(**kde_kwargs)
+                from numpy.random import default_rng
+
+                kde_maps = []
+                rng = default_rng(self.bootstrap_seed)
+                sample_size = container.size
+                for i in range(self.bootstrap_niter):
+                    # Indices of events are randomly chosen from the entire sample until
+                    # we have a new sample of the same size.
+                    # If we are stacking in PID, we will want to do this independently
+                    # for each PID channel.
+
+                    # We accumulate sample weights into one array.
+                    sample_weights = np.zeros(sample_size)
+
+                    if self.stack_pid:
+                        binning = self.regularized_apply_mode
+                        bin_edges = [b.bin_edges.m for b in binning]
+                        pid_bin = binning.names.index("pid")
+                        pid_bin_edges = bin_edges[pid_bin]
+
+                        n_ch = len(pid_bin_edges) - 1
+
+                        for pid_channel in range(n_ch):
+                            # Get mask of events falling into this PID bin
+                            pid_mask = (
+                                sample[:, pid_bin] >= pid_bin_edges[pid_channel]
+                            ) & (sample[:, pid_bin] < pid_bin_edges[pid_channel + 1])
+                            pid_size = np.sum(pid_mask)
+                            # Select indices of the appropriate size for just this PID
+                            # channel
+                            pid_sample_idx = rng.integers(pid_size, size=pid_size)
+                            # Instead of manipulating all of the data arrays, we count
+                            # how often each index was chosen and take that as a weight,
+                            # i.e. an event that was selected twice will have a weight
+                            # of 2.
+                            pid_sample_weights = np.bincount(
+                                pid_sample_idx, minlength=pid_size
+                            )
+                            sample_weights[pid_mask] += pid_sample_weights
+                        # Ensure that we indeed conserved the number of events in each
+                        # PID channel after all
+                        for pid_channel in range(n_ch):
+                            pid_mask = (
+                                sample[:, pid_bin] >= pid_bin_edges[pid_channel]
+                            ) & (sample[:, pid_bin] < pid_bin_edges[pid_channel + 1])
+                            assert sum(sample_weights[pid_mask]) == sum(pid_mask)
+                    else:
+                        sample_idx = rng.integers(sample_size, size=sample_size)
+                        # Instead of manipulating all of the data arrays, we count how
+                        # often each index was chosen and take that as a weight, i.e. an
+                        # event that was selected twice will have a weight of 2.
+                        sample_weights = np.bincount(sample_idx, minlength=sample_size)
+
+                    with np.errstate(invalid="raise"):
+                        try:
+                            kde_maps.append(
+                                kde_hist.kde_histogramdd(
+                                    weights=weights * sample_weights, **kde_kwargs
+                                )
+                            )
+                        except FloatingPointError:
+                            raise RuntimeError(
+                                "Could not calculate KDE with the given sample. This can "
+                                "happen if the bootstrap selects too few distinct events "
+                                "in one of the PID channels."
+                            )
+                kde_maps = np.stack(kde_maps)
+                kde_map = np.mean(kde_maps, axis=0)
+                kde_errors = np.std(kde_maps, axis=0)
                 kde_errors = np.ascontiguousarray(kde_errors.ravel())
             else:
-                kde_map = kde_histogramdd(**kde_kwargs)
+                kde_map = kde_hist.kde_histogramdd(weights=weights, **kde_kwargs)
             kde_map = np.ascontiguousarray(kde_map.ravel())
 
             self.data.representation = self.apply_mode
@@ -183,3 +258,11 @@ class kde(Stage):
         self.stash_valid = (
             self.stash_hists
         )  # valid is true if we are stashing, else not
+
+
+# Placing a unit test here creates an import error due to the fact that the class
+# defined above has the exact same name as the `kde` module that has to be imported to
+# make it work. If this script is __main__, then we import `kde` (the stage) directly
+# into the main scope and thus overshadow `kde` (the module).
+# The unit test for this stage is therefore instead placed in
+# pisa/pisa_tests/test_kde_stage.py

--- a/pisa_tests/test_command_lines.sh
+++ b/pisa_tests/test_command_lines.sh
@@ -53,6 +53,16 @@ echo "--------------------------------------------------------------------------
 echo ""
 echo ""
 
+echo "=============================================================================="
+echo "Running test_kde_stage.py"
+echo "=============================================================================="
+python $BASEDIR/test_kde_stage.py -v
+echo "------------------------------------------------------------------------------"
+echo "Finished Running test_kde_stage.py"
+echo "------------------------------------------------------------------------------"
+echo ""
+echo ""
+
 
 # TODO: all files except setup.py and __init__.py that are listed below should
 # have a command-line test defined further down in this script (i.e., these are

--- a/pisa_tests/test_kde_stage.py
+++ b/pisa_tests/test_kde_stage.py
@@ -1,0 +1,72 @@
+"""
+Module to test KDE bootstrapping. This could not be built into the KDE stage's script
+itself, because the import of a class named `kde` directly in the main scope overshadows
+the `kde` module and causes an import error.
+"""
+
+from copy import deepcopy
+from pisa.utils.log import logging, set_verbosity
+from pisa.core.distribution_maker import DistributionMaker
+from pisa.utils.config_parser import parse_pipeline_config
+from collections import OrderedDict
+
+
+def test_kde_bootstrapping():
+    """Unit test for the kde stage."""
+
+    example_cfg = parse_pipeline_config("settings/pipeline/example.cfg")
+
+    # We have to remove containers with too few events, otherwise the KDE fails simply
+    # because too few distinct events are in one of the PID channels after bootstrapping.
+    example_cfg[("data", "simple_data_loader")]["output_names"] = [
+        "numu_cc",
+        "numubar_cc",
+    ]
+
+    kde_stage_cfg = OrderedDict()
+    kde_stage_cfg["apply_mode"] = example_cfg[("utils", "hist")]["apply_mode"]
+    kde_stage_cfg["calc_mode"] = "events"
+    kde_stage_cfg["bootstrap"] = False
+    kde_stage_cfg["bootstrap_seed"] = 0
+    kde_stage_cfg["bootstrap_niter"] = 5
+
+    kde_pipe_cfg = deepcopy(example_cfg)
+
+    # Replace histogram stage with KDE stage
+    del kde_pipe_cfg[("utils", "hist")]
+    kde_pipe_cfg[("utils", "kde")] = kde_stage_cfg
+
+    # no errors in baseline since there is no bootstrapping enabled
+    kde_pipe_cfg["pipeline"]["output_key"] = "weights"
+
+    # get a baseline
+    dmaker = DistributionMaker([kde_pipe_cfg])
+    map_baseline = dmaker.get_outputs(return_sum=True)[0]
+    logging.debug(f"Baseline KDE'd map:\n{map_baseline}")
+
+    # Make sure that different seeds produce different maps, and that the same seed will
+    # produce the same map.
+    # We enable bootstrapping now, without re-loading everything, to save time.
+    dmaker.pipelines[0].output_key = ("weights", "errors")
+    dmaker.pipelines[0].stages[-1].bootstrap = True
+
+    map_seed0 = dmaker.get_outputs(return_sum=True)[0]
+    dmaker.pipelines[0].stages[-1].bootstrap_seed = 1
+    map_seed1 = dmaker.get_outputs(return_sum=True)[0]
+
+    logging.debug(f"Map with seed 0 is:\n{map_seed0}")
+    logging.debug(f"Map with seed 1 is:\n{map_seed1}")
+
+    assert not map_seed0 == map_seed1
+
+    dmaker.pipelines[0].stages[-1].bootstrap_seed = 0
+    map_seed0_reprod = dmaker.get_outputs(return_sum=True)[0]
+
+    assert map_seed0 == map_seed0_reprod
+
+    logging.info("<< PASS : kde_bootstrapping >>")
+
+
+if __name__ == "__main__":
+    set_verbosity(1)
+    test_kde_bootstrapping()

--- a/pisa_tests/test_kde_stage.py
+++ b/pisa_tests/test_kde_stage.py
@@ -5,14 +5,35 @@ the `kde` module and causes an import error.
 """
 
 from copy import deepcopy
-from pisa.utils.log import logging, set_verbosity
+from argparse import ArgumentParser
+from pisa.utils.log import logging, set_verbosity, Levels
 from pisa.core.distribution_maker import DistributionMaker
 from pisa.utils.config_parser import parse_pipeline_config
 from collections import OrderedDict
 
+__all__ = ["test_kde_bootstrapping"]
 
-def test_kde_bootstrapping():
+__author__ = "A. Trettin"
+
+__license__ = """Copyright (c) 2014-2020, The IceCube Collaboration
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License."""
+
+
+def test_kde_bootstrapping(verbosity=Levels.WARN):
     """Unit test for the kde stage."""
+
+    set_verbosity(verbosity)
 
     example_cfg = parse_pipeline_config("settings/pipeline/example.cfg")
 
@@ -67,6 +88,22 @@ def test_kde_bootstrapping():
     logging.info("<< PASS : kde_bootstrapping >>")
 
 
+def parse_args(description=__doc__):
+    """Parse command line arguments"""
+    parser = ArgumentParser(description=description)
+    parser.add_argument(
+        "-v", action="count", default=Levels.WARN, help="set verbosity level"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    """Script interface to test_kde_bootstrapping"""
+    args = parse_args()
+    kwargs = vars(args)
+    kwargs["verbosity"] = kwargs.pop("v")
+    test_kde_bootstrapping(**kwargs)
+
 if __name__ == "__main__":
-    set_verbosity(1)
-    test_kde_bootstrapping()
+    main()


### PR DESCRIPTION
This PR makes the KDE bootstrapping that we use to estimate MC errors on KDE'd histograms reproducible. Since the `kde` module didn't support setting seeds, I had to "in-source" the bootstrapping into the KDE stage itself to do this. I also added unit tests to ensure that the histograms with errors will give the same result with the same seed and different results with different seeds.