### PR TITLE
Add missing method to assert compatibility

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,10 +36,13 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test PISA example pipelines
       run: |
+        pip install pytest
         PISA_FTYPE=fp32 PISA_TARGET=cpu MPLBACKEND=agg ./pisa_tests/test_example_pipelines.py -v
     - name: Test PISA imports and unit tests, double precision
       run: |
+        pip install pytest
         PISA_FTYPE=fp64 PISA_TARGET=cpu MPLBACKEND=agg ./pisa_tests/run_unit_tests.py -v
     - name: Test PISA imports and unit tests, single precision
       run: |
+        pip install pytest
         PISA_FTYPE=fp32 PISA_TARGET=cpu MPLBACKEND=agg ./pisa_tests/run_unit_tests.py -v

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ EXTRAS_REQUIRE = {
         'sphinx>=1.3',
         'sphinx_rtd_theme',
         'versioneer',
+        'pytest',
     ],
     # TODO: get mceq install to work... this is non-trivial since that
     # project isn't exactly cleanly instllable via pip already, plus it


### PR DESCRIPTION
The `assert_compat` method was missing from the OneDimBinning class, and therefore the `assert_compat` method from the MultiDimBinning class would fail with an obscure error. This PR fixes this behavior and adds a unit test to ensure that the appropriate error is raised.