### PR TITLE
Compatibility with Python 3.10

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, ]
+        python-version: [3.7, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.10]
+        python-version: [3.7, 3.10.4]
 
     steps:
     - uses: actions/checkout@v2

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -21,7 +21,7 @@ import numba
 from numba import njit, prange
 # When binnings are fully regular, we can use this for super speed
 import fast_histogram as fh
-from collections import Iterable
+from collections.abc import Iterable
 
 from concurrent.futures import ThreadPoolExecutor
 


### PR DESCRIPTION
Make PISA compatible with Python 3.10. Hopefully this will not be too painful.