### PR TITLE
Better KDE unit tests

### DIFF
--- a/pisa/utils/kde_hist.py
+++ b/pisa/utils/kde_hist.py
@@ -124,7 +124,7 @@ def get_hist(
     # the bin range for reflection
     bin_points = []
     for b in binning:
-        c = unp.nominal_values(b.weighted_centers)
+        c = b.weighted_centers.m
         if b.name == coszen_name:
             # how many bins to add for reflection
             l = int(len(c) * coszen_reflection)

--- a/pisa_tests/test_kde_stage.py
+++ b/pisa_tests/test_kde_stage.py
@@ -12,11 +12,17 @@ from pisa.core.distribution_maker import DistributionMaker
 from pisa.utils.config_parser import parse_pipeline_config
 from collections import OrderedDict
 
-__all__ = ["test_kde_bootstrapping"]
+from pisa.core.binning import MultiDimBinning, OneDimBinning
+from pisa.core.param import Param, ParamSet
+from pisa.core.prior import Prior
+from pisa import ureg
+
+
+__all__ = ["test_kde_bootstrapping", "test_kde_stash"]
 
 __author__ = "A. Trettin"
 
-__license__ = """Copyright (c) 2014-2020, The IceCube Collaboration
+__license__ = """Copyright (c) 2014-2022, The IceCube Collaboration
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -31,44 +37,110 @@ __license__ = """Copyright (c) 2014-2020, The IceCube Collaboration
  limitations under the License."""
 
 
+PARAM_DEFAULTS = {"prior": None, "range": None, "is_fixed": True}
+"""Defaults for stage parameters."""
+
+TEST_BINNING = MultiDimBinning(
+    [
+        OneDimBinning(
+            name="true_energy",
+            is_log=True,
+            num_bins=15,
+            domain=[10, 100] * ureg.GeV,
+            tex=r"E_{\rm true}",
+        ),
+        OneDimBinning(
+            name="true_coszen",
+            is_log=False,
+            num_bins=16,
+            domain=[-1, 0] * ureg.dimensionless,
+            tex=r"\cos(\theta_z)",
+        ),
+    ]
+)
+"""Binning to use for test pipeline."""
+
+
+class TEST_CONFIGS(object):
+    """Default configurations for stages in a minimal test pipeline."""
+
+    pipe_cfg = OrderedDict(
+        pipeline={
+            "name": "muons",
+            "output_binning": TEST_BINNING,
+            "output_key": ("weights"),
+            "detector_name": None,
+        }
+    )
+    event_generator_cfg = {
+        "calc_mode": "events",
+        "apply_mode": "events",
+        "output_names": ["muon"],
+        "params": ParamSet(
+            [
+                Param(name="n_events", value=1e3, **PARAM_DEFAULTS),
+                Param(name="seed", value=0, **PARAM_DEFAULTS),
+                Param(name="random", value=False, **PARAM_DEFAULTS),
+            ]
+        ),
+    }
+    aeff_cfg = {
+        "calc_mode": "events",
+        "apply_mode": "events",
+        "params": ParamSet(
+            [
+                Param(name="livetime", value=12345 * ureg["seconds"], **PARAM_DEFAULTS),
+                Param(name="weight_scale", value=1.0, **PARAM_DEFAULTS),
+            ]
+        ),
+    }
+    set_variance_cfg = {
+        "calc_mode": TEST_BINNING,
+        "apply_mode": TEST_BINNING,
+        "divide_total_mc": True,
+        # expected number of unweighted MC events including events that fall outside of
+        # the analysis binning
+        "expected_total_mc": 1000,
+        "variance_scale": 0.1,
+    }
+    fix_error_cfg = {
+        "calc_mode": TEST_BINNING,
+        "apply_mode": TEST_BINNING,
+    }
+    kde_cfg = {
+        "calc_mode": "events",
+        "apply_mode": TEST_BINNING,
+        "bootstrap": False,
+        "bootstrap_seed": 0,
+        "bootstrap_niter": 6,
+        "linearize_log_dims": True,
+        "stash_hists": False,
+        "coszen_name": "true_coszen",
+        "stack_pid": False,
+        "oversample": 1,
+    }
+
+
 def test_kde_bootstrapping(verbosity=Levels.WARN):
     """Unit test for the kde stage."""
 
     set_verbosity(verbosity)
 
-    example_cfg = parse_pipeline_config("settings/pipeline/example.cfg")
-
-    # We have to remove containers with too few events, otherwise the KDE fails simply
-    # because too few distinct events are in one of the PID channels after bootstrapping.
-    example_cfg[("data", "simple_data_loader")]["output_names"] = [
-        "numu_cc",
-        "numubar_cc",
-    ]
-
-    kde_stage_cfg = OrderedDict()
-    kde_stage_cfg["apply_mode"] = example_cfg[("utils", "hist")]["apply_mode"]
-    kde_stage_cfg["calc_mode"] = "events"
-    kde_stage_cfg["bootstrap"] = False
-    kde_stage_cfg["bootstrap_seed"] = 0
-    kde_stage_cfg["bootstrap_niter"] = 5
-
-    kde_pipe_cfg = deepcopy(example_cfg)
-
-    # Replace histogram stage with KDE stage
-    del kde_pipe_cfg[("utils", "hist")]
-    kde_pipe_cfg[("utils", "kde")] = kde_stage_cfg
-
-    # no errors in baseline since there is no bootstrapping enabled
-    kde_pipe_cfg["pipeline"]["output_key"] = "weights"
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
 
     # get map, but without the linearization
-    kde_pipe_cfg[("utils", "kde")]["linearize_log_dims"] = False
-    dmaker = DistributionMaker([kde_pipe_cfg])
+    test_cfg[("utils", "kde")]["linearize_log_dims"] = False
+    dmaker = DistributionMaker([test_cfg])
     map_baseline_no_linearization = dmaker.get_outputs(return_sum=True)[0]
 
     # get a baseline (with linearization, which we will use from here on out)
-    kde_pipe_cfg[("utils", "kde")]["linearize_log_dims"] = True
-    dmaker = DistributionMaker([kde_pipe_cfg])
+    test_cfg[("utils", "kde")]["linearize_log_dims"] = True
+    dmaker = DistributionMaker([test_cfg])
     map_baseline = dmaker.get_outputs(return_sum=True)[0]
     logging.debug(f"Baseline KDE'd map:\n{map_baseline}")
 
@@ -104,6 +176,173 @@ def test_kde_bootstrapping(verbosity=Levels.WARN):
     logging.info("<< PASS : kde_bootstrapping >>")
 
 
+def test_kde_stash(verbosity=Levels.WARN):
+    """Unit test for the hist stashing feature.
+
+    Hist stashing can greatly speed up fits as long as the only free parameters
+    are in stages that work on the output histograms, rather than the individual
+    events. In particular, it should be strictly equivalent to either scale all weights
+    by a factor and then running the KDE, or to first calculate the KDE and then scale
+    all the bin counts by the same factor. This test ensures that the order of
+    operation really doesn't matter.
+
+    This should apply also to the errors, independent of whether the bootstrapping
+    method or the utils.set_variance stage was used to produce them.
+    """
+
+    import pytest
+    from numpy.testing import assert_array_equal, assert_allclose
+
+    set_verbosity(verbosity)
+
+    def assert_correct_scaling(pipeline_cfg, fixed_errors=False):
+        """Run the pipeline and assert that scaling by a factor of two is correct."""
+        dmaker = DistributionMaker([pipeline_cfg])
+        out = dmaker.get_outputs(return_sum="true")[0]
+        dmaker.pipelines[0].params.weight_scale = 2.0
+        out2 = dmaker.get_outputs(return_sum="true")[0]
+        if fixed_errors:
+            # this is special: We expect that the nominal counts are multiplied, but
+            # that hte errors stay fixed (applies to set_variance errors)
+            assert_array_equal(out.nominal_values * 2.0, out2.nominal_values)
+            assert_array_equal(out.std_devs, out2.std_devs)
+        else:
+            assert out * 2.0 == out2
+
+    ## KDE without errors
+
+    # First aeff, then KDE
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    assert_correct_scaling(test_cfg)
+
+    # First KDE, then aeff, with stashing
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    # turn on stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = True
+    # Change aeff calculation to binned mode (i.e. multiply bin counts)
+    test_cfg[("aeff", "weight")]["calc_mode"] = TEST_BINNING
+    test_cfg[("aeff", "weight")]["apply_mode"] = TEST_BINNING
+    assert_correct_scaling(test_cfg)
+
+    ## KDE with bootstrap errors
+
+    # First aeff, then KDE with bootstrap
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    # turn OFF stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = False
+    # turn on bootstrapping
+    test_cfg[("utils", "kde")]["bootstrap"] = True
+    # return the errors
+    test_cfg["pipeline"]["output_key"] = ("weights", "errors")
+    assert_correct_scaling(test_cfg)
+
+    # First KDE with stashed hists and bootstrap, then aeff
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    # turn on stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = True
+    # turn on bootstrapping
+    test_cfg[("utils", "kde")]["bootstrap"] = True
+    # return the errors
+    test_cfg["pipeline"]["output_key"] = ("weights", "errors")
+    # need to change mode to binned
+    test_cfg[("aeff", "weight")]["calc_mode"] = TEST_BINNING
+    test_cfg[("aeff", "weight")]["apply_mode"] = TEST_BINNING
+    assert_correct_scaling(test_cfg)
+
+    ## KDE with errors calculated using set_variance stage
+
+    # first aeff, then KDE and set_variance
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    test_cfg[("utils", "set_variance")] = deepcopy(TEST_CONFIGS.set_variance_cfg)
+    # turn on stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = False
+    # turn OFF bootstrapping
+    test_cfg[("utils", "kde")]["bootstrap"] = False
+    # return the errors
+    test_cfg["pipeline"]["output_key"] = ("weights", "errors")
+    # The set_variance stage only calculates errors the first time that the pipeline
+    # is evaluated, these errors are stored and re-instated on any sub-sequent
+    # evaluations. We expect therefore that only the nominal values scale.
+    assert_correct_scaling(test_cfg, fixed_errors=True)
+
+    # first KDE and set_variance, then aeff
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    # It is still important that the `set_variance` stage is *last*.
+    test_cfg[("utils", "set_variance")] = deepcopy(TEST_CONFIGS.set_variance_cfg)
+    # turn on stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = True
+    # turn OFF bootstrapping
+    test_cfg[("utils", "kde")]["bootstrap"] = False
+    # return the errors
+    test_cfg["pipeline"]["output_key"] = ("weights", "errors")
+    # need to change mode to binned
+    test_cfg[("aeff", "weight")]["calc_mode"] = TEST_BINNING
+    test_cfg[("aeff", "weight")]["apply_mode"] = TEST_BINNING
+    # We ensure that the behavior is the same as it has been when we were not stashing
+    # the histograms and used set_variance.
+    assert_correct_scaling(test_cfg, fixed_errors=True)
+
+    # Using the wrong order (not putting set_variance last)
+    test_cfg = deepcopy(TEST_CONFIGS.pipe_cfg)
+    test_cfg[("data", "toy_event_generator")] = deepcopy(
+        TEST_CONFIGS.event_generator_cfg
+    )
+    test_cfg[("utils", "kde")] = deepcopy(TEST_CONFIGS.kde_cfg)
+    # If set_variance is not the last stage, this breaks. The reason is a slightly
+    # silly design of set_variance. It should have been constructed such that the
+    # total normalization is always divided out, but it wasn't. The way it is
+    # constructed now, it is basically tuned by the scaling factor to work for the
+    # given livetime and breaks immediately when that changes.
+    test_cfg[("utils", "set_variance")] = deepcopy(TEST_CONFIGS.set_variance_cfg)
+    test_cfg[("aeff", "weight")] = deepcopy(TEST_CONFIGS.aeff_cfg)
+    # turn on stashing
+    test_cfg[("utils", "kde")]["stash_hists"] = True
+    # turn OFF bootstrapping
+    test_cfg[("utils", "kde")]["bootstrap"] = False
+    # return the errors
+    test_cfg["pipeline"]["output_key"] = ("weights", "errors")
+    # need to change mode to binned
+    test_cfg[("aeff", "weight")]["calc_mode"] = TEST_BINNING
+    test_cfg[("aeff", "weight")]["apply_mode"] = TEST_BINNING
+    # With the wrong order, this will fail.
+    # FIXME: If someone changes the behavior of set_variance in the future to be
+    # more robust, they are welcome to change this unit test.
+    with pytest.raises(AssertionError):
+        assert_correct_scaling(test_cfg, fixed_errors=True)
+
+    logging.info("<< PASS : kde_stash >>")
+
+
 def parse_args(description=__doc__):
     """Parse command line arguments"""
     parser = ArgumentParser(description=description)
@@ -116,10 +355,14 @@ def parse_args(description=__doc__):
 
 def main():
     """Script interface to test_kde_bootstrapping"""
+
     args = parse_args()
     kwargs = vars(args)
     kwargs["verbosity"] = kwargs.pop("v")
+
     test_kde_bootstrapping(**kwargs)
+    test_kde_stash(**kwargs)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds unit testing for the "stashing" feature of the KDE to ensure that scaling stashed histograms with a subsequent weighting stage is strictly equivalent to scaling the weights first before applying the KDE. The behavior of errors is tested with both bootstrapped errors and errors set ad-hoc with the `set_variance` stage (the latter is aimed at backward compatibility with the verification sample). 

The KDE unit test also uses a much faster testing pipeline now, reducing the runtime for this unit test from 20 s to ~1 s. 

One further small tidbit is that I tracked down the origin of the `UnitStrippedWarning` one always gets when running the KDE stage and fixed the offending line. This has annoyed me for a long time.