### PR TITLE
fix resetting parameter values for 2. octant fit

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -1046,7 +1046,7 @@ class BasicAnalysis(object):
             # store so we can reset to the values we currently have rather than
             # resetting free parameters back to their nominal value after the octant
             # check
-            minimizer_start_params = hypo_maker.params
+            minimizer_start_params = deepcopy(hypo_maker.params)
 
         tolerance = method_kwargs["tolerance"] if "tolerance" in method_kwargs else None
         # Get new angle parameters each limited to one octant


### PR DESCRIPTION
In octant fitting, if parameter values are not reset free between the single fits, the intended behavior is that after fitting the first octant, the parameter values (except for theta_23) are reset to where the first fit started. Due to the missing deepcopy, instead, they were set to the end point of the first fit instead.