### PR TITLE
fix resetting parameter values for 2. octant fit

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -1046,7 +1046,7 @@ class BasicAnalysis(object):
             # store so we can reset to the values we currently have rather than
             # resetting free parameters back to their nominal value after the octant
             # check
-            minimizer_start_params = hypo_maker.params
+            minimizer_start_params = deepcopy(hypo_maker.params)
 
         tolerance = method_kwargs["tolerance"] if "tolerance" in method_kwargs else None
         # Get new angle parameters each limited to one octant

--- a/pisa/utils/stats.py
+++ b/pisa/utils/stats.py
@@ -482,6 +482,7 @@ def conv_llh(actual_values, expected_values):
         `expected_values`.
 
     """
+    in_array_shape = np.shape(actual_values)
     actual_values = unp.nominal_values(actual_values).ravel()
     sigma = unp.std_devs(expected_values).ravel()
     expected_values = unp.nominal_values(expected_values).ravel()

--- a/pisa_tests/run_unit_tests.py
+++ b/pisa_tests/run_unit_tests.py
@@ -76,8 +76,11 @@ OPTIONAL_MODULES = (
 
 REQUIRED_MODULES = (
     "pisa",
-    "pip",
+    # It is important that setuptools comes *before* pip! If pip is imported before
+    # setuptools, it will trigger an assertion error when the version of setuptools is
+    # >= 60.0.0. This bug is mentioned in https://github.com/pypa/setuptools/issues/3089
     "setuptools",
+    "pip",
     "numpy",
     "decorator",
     "kde",

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ INSTALL_REQUIRES = [
     'matplotlib>=3.0', # 1.5: inferno colormap; 2.0: 'C0' colorspec
     'numba>=0.53', # >=0.35: fastmath jit flag; >=0.38: issue #439; 0.44 segfaults
     'numpy>=1.17',
-    'pint>=0.8.1', # see https://github.com/hgrecco/pint/issues/512
+    'pint<=0.19', # property pint.quantity._Quantity no longer exists in 0.20
     'scipy>=1.6',
     'pandas',
     'simplejson>=3.2',


### PR DESCRIPTION
In octant fitting, if parameter values are not reset free between the single fits, the intended behavior is that after fitting the first octant, the parameter values (except for theta_23) are reset to where the first fit started. Due to the missing deepcopy, instead, they were set to the end point of the first fit instead.