### PR TITLE
Clongdouble alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ pisa.egg-info
 
 # IPython notebook backups
 .ipynb_checkpoints
+pisa/utils/llh_defs/poisson_gamma_mixtures.c

--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -18,8 +18,11 @@ from numpy import (
     float32, float64,
     int0, int8, int16, int32, int64,
     uint0, uint8, uint16, uint32, uint64,
-    complex64, complex128, complex256,
+    complex64, complex128
 )
+# The alias only exists on Linux x86_64, see
+# https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.clongdouble
+from numpy import clongdouble as complex256
 import numpy as np
 from pint import UnitRegistry
 


### PR DESCRIPTION
Just a small change that allows PISA to run on platforms other than Linux x86_64.

Somehow, there is this alias, `complex256`, that only exists on x86_64 for `clongdouble`. No idea why that would be, the workaround is also very simply to set the alias manually.

https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.clongdouble

Oh, and I always get annoyed a little by this automatically generated file being shown as untracked in git, so I added that to `.gitignore`.