### PR TITLE
fixed small bug in `fit_scipy`

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -1746,7 +1746,13 @@ class BasicAnalysis(object):
         hypo_asimov_dist = hypo_maker.get_outputs(return_sum=True)
         
         # Check if the hypo matches data
-        if data_dist.allclose(hypo_asimov_dist) :
+        matches = False 
+        if isinstance(data_dist, list):
+            matches = all( entry.allclose(hypo_asimov_dist[ie]) for ie, entry in enumerate(data_dist) )
+        else:
+            matches = data_dist.allclose(hypo_asimov_dist)
+            
+        if matches:
 
             msg = 'Initial hypo matches data, no need for fit'
             logging.info(msg)


### PR DESCRIPTION
When the `_fit_scipy` function is called with a `list` of `MapSets`, it will still try to call `data_dist.allclose(hypo_asimov_dist)`, which fails since `data_dist` is a list. This is fixed by checking if this is a list first, and if so it will then check if all the mapsets are close instead.