### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, '3.10']
+        python-version: ['3.8', '3.10']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We don't support python 3.7 anymore so let's bump the python version for the github workflos.