### PR TITLE
Fix dependencies and update install instructions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install "pip<21.3"
         pip install .
     - name: Lint with flake8
       run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,86 @@
 ## Installation Guide
 
-### Quickstart
+### Instructions to install PISA on Madison working group servers cobalts (current guide from August 2023):
+
+Assuming you already are in the directory where you want to store fridge/pisa source files and the python virtualenv and build pisa. You also need access to github through your account.
+
+
+#### Clone into the fridge and pisa (ideally your own fork):
+
+```
+git clone git@github.com:icecube/wg-oscillations-fridge.git ./fridge
+
+git clone git@github.com:USERNAME/pisa.git ./pisa
+```
+
+
+#### Load cvmfs environment:
+
+```
+unset OS_ARCH; eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.2.1/setup.sh`
+```
+
+`which python` should now point to `/cvmfs/icecube.opensciencegrid.org/py3-v4.2.1/RHEL_7_x86_64/bin/python`
+
+**Note:** It's not tested whether this works with a cvmfs version newer than `py3-v4.2.1`.
+
+
+#### Create virtual environment:
+
+```
+python -m venv ./YOUR_PISA_PY3_VENV
+```
+
+
+#### Start the virtual environment and install pisa from source:
+
+```
+source ./YOUR_PISA_PY3_VENV/bin/activate
+```
+
+(should now show that you are in the environment)
+
+```
+pip install -e pisa
+```
+
+
+#### Modify your environment by adding lines to `./YOUR_PISA_PY3_VENV/bin/activate`
+
+Every time you want to use pisa now, you need to activate your virtual environment by running `source ./YOUR_PISA_PY3_VENV/bin/activate`. In order to set some useful environment variables you might want to add the following lines (or more if needed) to the end of the `./YOUR_PISA_PY3_VENV/bin/activate` script:
+
+```
+# PISA source
+export PISA="/data/user/USERNAME/PATH_TO_PISA"
+
+# set some custom environment variables and load fridge
+export PISA_RESOURCES="/data/user/USERNAME/PATH_TO_FRIDGE/analysis/common"
+export PISA_RESOURCES=$PISA_RESOURCES:"/data/user/USERNAME/PATH_TO_FRIDGE/analysis"
+
+source "/data/user/USERNAME/PATH_TO_FRIDGE/setup_fridge.sh"
+
+# Add this project to the python path
+export PYTHONPATH=$FRIDGE_DIR:$PYTHONPATH
+
+# Madison
+export PISA_RESOURCES=/data/ana/LE:$PISA_RESOURCES
+export PISA_RESOURCES=/data/ana/BSM/HNL/:$PISA_RESOURCES
+
+export PISA_RESOURCES=$FRIDGE_DIR:$FRIDGE_DIR/analysis:$FRIDGE_DIR/analysis/YOUR_ANALYSIS/settings:$FRIDGE_DIR/analysis/YOUR_ANALYSIS/analysis:$FRIDGE_DIR/analysis/common:$PISA_RESOURCES
+
+export PISA_CACHE=~/cache/
+export PISA_FTYPE=fp64
+export HDF5_USE_FILE_LOCKING='FALSE'
+```
+
+
+#### Install any additional packages that you might want
+
+`pip install PACKAGE` (for example `jupyter`)
+
+
+
+### Quickstart (old guide)
 
 _Note that terminal commands below are intended for the bash shell. You'll have to translate if you use a different shell._
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ __license__ = '''Copyright (c) 2014-2020, The IceCube Collaboration
 
 
 SETUP_REQUIRES = [
-    'pip>=1.8',
+    'pip>=1.8,<21.3',
     'setuptools>18.5,<60.0', # versioneer requires >18.5
     'numpy>=1.17,<1.23',
     'cython~=0.29.0', # needed for the setup and for the install

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ __license__ = '''Copyright (c) 2014-2020, The IceCube Collaboration
 
 SETUP_REQUIRES = [
     'pip>=1.8',
-    'setuptools>18.5', # versioneer requires >18.5
-    'numpy>=1.17',
+    'setuptools>18.5,<60.0', # versioneer requires >18.5
+    'numpy>=1.17,<1.23',
     'cython~=0.29.0', # needed for the setup and for the install
     'scikit-learn<=1.1.2',
 ]
@@ -93,7 +93,7 @@ INSTALL_REQUIRES = [
     'line_profiler',
     'matplotlib>=3.0', # 1.5: inferno colormap; 2.0: 'C0' colorspec
     'numba>=0.53', # >=0.35: fastmath jit flag; >=0.38: issue #439; 0.44 segfaults
-    'numpy>=1.17',
+    'numpy>=1.17,<1.23',
     'pint<=0.19', # property pint.quantity._Quantity no longer exists in 0.20
     'scipy>=1.6',
     'pandas',


### PR DESCRIPTION
Nail down a few dependency version ranges, so install does not break. Also fix pip maximum version in git workflow, to be compatible with setuptools older version.