### PR TITLE
Remove misleading line in fix_error.py description

### DIFF
--- a/pisa/stages/utils/fix_error.py
+++ b/pisa/stages/utils/fix_error.py
@@ -1,8 +1,6 @@
 """
 Stage to take the initial errors of MC and keep them
 for all minimization.
-
-Needed to allow mod_chi2 to behave correctly
 """
 
 from __future__ import absolute_import, print_function, division


### PR DESCRIPTION
Previously said: "Needed to allow mod_chi2 to behave correctly".  My understanding is that this stage reduces the accuracy of mod_chi2 by approximating MC errors throughout the space as the initial MC errors.