### PR TITLE
Add warning when attempting to use the analytical NSI matrix

### DIFF
--- a/pisa/stages/osc/nsi_params.py
+++ b/pisa/stages/osc/nsi_params.py
@@ -388,6 +388,9 @@ class VacuumLikeNSIParams(NSIParams):
     def eps_matrix_analytical(self):
         """Effective NSI coupling matrix calculated analytically."""
         # Analytical relations. These are wrong right now! #FIXME
+
+        logging.warning("Warning: the analytical NSI matrix is not yet properly implemented. Instead, use the numerical NSI matrix.")
+        
         nsi_eps = np.zeros((3, 3, 2), dtype=FTYPE)
 
         sp12 = np.sin(self.phi12)


### PR DESCRIPTION
According to an existing comment (L390 of the edited file), the analytical version of the NSI matrix is not implemented correctly.  Since this function is called in the PISA tests that run on changes to be merged, I'm writing a warning here rather than an error.