### PR TITLE
Raise an exeption if the (not entirely implemented) analytical versio…

### DIFF
--- a/pisa/stages/osc/nsi_params.py
+++ b/pisa/stages/osc/nsi_params.py
@@ -388,6 +388,9 @@ class VacuumLikeNSIParams(NSIParams):
     def eps_matrix_analytical(self):
         """Effective NSI coupling matrix calculated analytically."""
         # Analytical relations. These are wrong right now! #FIXME
+
+        raise NotImplementedError("The analytical veresion of the effective NSI coupling matrix is not yet implemented.")
+        
         nsi_eps = np.zeros((3, 3, 2), dtype=FTYPE)
 
         sp12 = np.sin(self.phi12)


### PR DESCRIPTION
…n of the effective NSI coupling matrix is accessed