### PR TITLE
fix plotting 2d arrays (not caught by unit tests)

### DIFF
--- a/pisa/utils/plotter.py
+++ b/pisa/utils/plotter.py
@@ -299,8 +299,7 @@ class Plotter(object):
             raise TypeError('Expecting to plot a MapSet but '
                             'got %s'%type(map_set))
         if n_rows is None and n_cols is None:
-            # TODO: auto row/cols
-            n_rows = np.floor(np.sqrt(n))
+            n_rows = int(np.floor(np.sqrt(n)))
             while n % n_rows != 0:
                 n_rows -= 1
             n_cols = n // n_rows


### PR DESCRIPTION
At least in matplotlib 3.8.4, `plt.subplot` doesn't accept a float for the number of rows/columns, only an integer. This leads to exceptions when trying to run scripts `distribution_maker.py`, `kde_hist.py`, etc. with plotting activated. I believe only the unit test for `kde_hist.py` could have caught this, but it fails due to the missing (but accepted) pycuda dependency already.

It doesn't seem worth checking whether previous versions of matplotlib were more lenient, because passing an integer is surely backwards compatible, isn't it? I've also removed the very old TODO in the line above because there is an automatic row/column setup...