### PR TITLE
Finally fix map.plot, to be actually usable..

### DIFF
--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -783,7 +783,7 @@ class OneDimBinning(object):
         if self.units == ureg.dimensionless:
             units_tex = ''
         else:
-            units_tex = r' \; \left( {:~L} \right)'.format(self.units)
+            units_tex = r' \; \left[ {:~L} \right]'.format(self.units)
 
         return name_tex + units_tex
 


### PR DESCRIPTION
Added some extra parameters to the map plotting function, which now allow:
1. using the raw bin names (from the binning config file) as title for each pid bin, by setting `pure_bin_names=True`
2. using `'layout': 'tight'` or `'layout': 'constrained'` in `fig_kw`, to produce reasonable saved figures

The second point did not work before, because the colorbar was plotted 3 times for every pid bin, and not all of them were correctly moved by the layout option.. now it is keeping track of the main axis and only plotting the colorbar once. Results are rather nice now, as you can see here:

 ![labeled_s_to_sqrt_b_0 3_GeV_combined_U_tau4_sq_0 0100_total](https://github.com/user-attachments/assets/e2f2a8c1-be06-4b8a-bebc-9772c1b1fa07)
