### PR TITLE
Apply obvious outstanding fixes to `simple_signal` and `generalized_llh_params` services

### DIFF
--- a/pisa/stages/data/super_simple_pipeline.cfg
+++ b/pisa/stages/data/super_simple_pipeline.cfg
@@ -6,14 +6,13 @@ super_simple_binning.stuff = {'bin_edges':np.linspace(0.,40.,51)}
 
 [data.simple_signal]
 
-input_specs  = None
-calc_specs   = None
-output_specs = super_simple_binning
+calc_mode = None
+apply_mode = super_simple_binning
 
 
-param.n_events_data = None
-param.signal_fraction = None
-param.stats_factor = None
+param.n_events_data = 10e3
+param.signal_fraction = 0.5
+param.stats_factor = 10
 param.bkg_min = 0.
 param.bkg_max = 40.
 
@@ -28,14 +27,11 @@ param.sigma.fixed = True
 [likelihood.generalized_llh_params]
 
 
-input_specs = None
-calc_specs = None
-output_specs = super_simple_binning
-
-# Arguments to turn pseudo weight and mean adjustment on and off
-with_pseudo_weight = False
-with_mean_adjust = False
+calc_mode = None
+apply_mode = super_simple_binning
 
 [pipeline]
 
 order = data.simple_signal, likelihood.generalized_llh_params
+output_binning = super_simple_binning
+output_key = weights, errors

--- a/pisa/stages/likelihood/generalized_llh_params.py
+++ b/pisa/stages/likelihood/generalized_llh_params.py
@@ -109,7 +109,7 @@ class generalized_llh_params(Stage):
  
             for index in range(N_bins):
                 index_mask = container['bin_{}_mask'.format(index)]
-                if 'kfold_mask' in container:
+                if 'kfold_mask' in container.keys:
                     index_mask*=container['kfold_mask']
                 # Number of MC events in each bin
                 nevents_sim[index] = np.sum(index_mask)
@@ -127,7 +127,7 @@ class generalized_llh_params(Stage):
                 mean_adjustment = -(1.0-mean_number_of_mc_events) + 1.e-3
             else:
                 mean_adjustment = 0.0
-            container.set_aux_data(key='mean_adjustment', data=mean_adjustment)
+            container.set_aux_data(key='mean_adjustment', val=mean_adjustment)
  
  
             #
@@ -135,7 +135,7 @@ class generalized_llh_params(Stage):
             # (to avoid errors in get_outputs, if we want )
             # these to be returned when you call get_output
             #
-            if 'hs_scales' not in container.keys():
+            if 'hs_scales' not in container.keys:
                 container['hs_scales'] =  np.empty((container.size), dtype=FTYPE)
                 container['errors'] = np.empty((container.size), dtype=FTYPE)
  
@@ -166,7 +166,7 @@ class generalized_llh_params(Stage):
             # for this part we are in events mode
             # Find the minimum weight of an entire MC set
             pseudo_weight = 0.001
-            container.set_aux_data(key='pseudo_weight', data=pseudo_weight)
+            container.set_aux_data(key='pseudo_weight', val=pseudo_weight)
 
             old_weight_sum = np.zeros(N_bins)
             new_weight_sum = np.zeros(N_bins)
@@ -176,13 +176,13 @@ class generalized_llh_params(Stage):
             #
             # Load the pseudo_weight and mean displacement values
             #
-            mean_adjustment = container.scalar_data['mean_adjustment']
-            pseudo_weight = container.scalar_data['pseudo_weight']
+            mean_adjustment = container['mean_adjustment']
+            pseudo_weight = container['pseudo_weight']
 
             for index in range(N_bins):
 
                 index_mask = container['bin_{}_mask'.format(index)]
-                if 'kfold_mask' in container:
+                if 'kfold_mask' in container.keys:
                     index_mask*=container['kfold_mask']
                 current_weights = container['weights'][index_mask]
 


### PR DESCRIPTION
* seems these were forgotten when `Container` methods were changed
* also make "super simple" pipeline config work again (kept here for now; something like this should probably be integrated into examples eventually instead)
* closes #784 