### PR TITLE
Add link to general PISA conventions in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [Installation](INSTALL.md) |
 [Documentation](https://icecube.github.io/pisa/) |
 [Terminology](pisa/glossary.md) |
+[Conventions](pisa/general_conventions.md) |
 [License](LICENSE)
 
 PISA is a software written to analyze the results (or expected results) of an experiment based on Monte Carlo simulation.

--- a/pisa/general_conventions.md
+++ b/pisa/general_conventions.md
@@ -42,7 +42,6 @@ Docstrings should be formatted according to the NumPy/SciPy convention.
 * [NumPy/SciPy documentation style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
 * [Example NumPy docstrings in code](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
 * [Recommonmark translates markdown into reST](http://recommonmark.readthedocs.io/en/latest/auto_structify.html)
-* Since all documentation will be run through Sphinx using the Napoleon and Recommonmark extensions, the final arbiter on whether a docstring is formatted correctly is the output generated using these. Good information for making nice docstrings can be found in both [Napoleon](http://sphinxcontrib-napoleon.readthedocs.io/)
 
 ## Standalone files
 


### PR DESCRIPTION
In the absence of a dedicated [contributing guide](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), at least add link to conventions (which includes some information typically found in a _CONTRIBUTING_ file) to readme in root directory.