### PR TITLE
Allow reporting timing data for several pipelines at once (from any `Detectors` or `DistributionMaker` instance) ...

### DIFF
--- a/pisa/core/detectors.py
+++ b/pisa/core/detectors.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from collections import OrderedDict
 import inspect
-from itertools import product
 import os
 from tabulate import tabulate
 from copy import deepcopy
@@ -21,7 +20,6 @@ from copy import deepcopy
 import numpy as np
 
 from pisa import ureg
-from pisa.core.map import MapSet
 from pisa.core.pipeline import Pipeline
 from pisa.core.distribution_maker import DistributionMaker
 from pisa.core.param import ParamSet, Param
@@ -112,10 +110,15 @@ class Detectors(object):
     def __iter__(self):
         return iter(self._distribution_makers)
 
-    def report_profile(self, detailed=False):
+    def report_profile(self, detailed=False, format_num_kwargs=None):
+        """Report timing information on contained distribution makers.
+        See `Pipeline.report_profile` for details.
+        """
         for distribution_maker in self._distribution_makers:
             print(distribution_maker.detector_name + ':')
-            distribution_maker.report_profile(detailed=detailed)
+            distribution_maker.report_profile(
+                detailed=detailed, format_num_kwargs=format_num_kwargs
+            )
 
     @property
     def profile(self):

--- a/pisa/core/detectors.py
+++ b/pisa/core/detectors.py
@@ -66,7 +66,7 @@ class Detectors(object):
         self._distribution_makers , self.det_names = [] , []
         for pipeline in pipelines:
             if not isinstance(pipeline, Pipeline):
-                pipeline = Pipeline(pipeline)
+                pipeline = Pipeline(pipeline, profile=profile)
             
             name = pipeline.detector_name
             if name in self.det_names:
@@ -111,7 +111,12 @@ class Detectors(object):
             
     def __iter__(self):
         return iter(self._distribution_makers)
-    
+
+    def report_profile(self, detailed=False):
+        for distribution_maker in self._distribution_makers:
+            print(distribution_maker.detector_name + ':')
+            distribution_maker.report_profile(detailed=detailed)
+
     @property
     def profile(self):
         return self._profile

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -104,6 +104,8 @@ class DistributionMaker(object):
         for pipeline in pipelines:
             if not isinstance(pipeline, Pipeline):
                 pipeline = Pipeline(pipeline, profile=profile)
+            else:
+                pipeline.profile = profile
             self._pipelines.append(pipeline)
 
         data_run_livetime = None
@@ -214,6 +216,11 @@ class DistributionMaker(object):
 
     def __iter__(self):
         return iter(self._pipelines)
+
+    def report_profile(self, detailed=False):
+        for pipeline in self.pipelines:
+            print(pipeline.name + ':')
+            pipeline.report_profile(detailed=detailed)
 
     @property
     def profile(self):

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -219,7 +219,6 @@ class DistributionMaker(object):
 
     def report_profile(self, detailed=False):
         for pipeline in self.pipelines:
-            print(pipeline.name + ':')
             pipeline.report_profile(detailed=detailed)
 
     @property
@@ -232,8 +231,8 @@ class DistributionMaker(object):
             pipeline.profile = value
         self._profile = value
 
-
     def run(self):
+        """Run all pipelines"""
         for pipeline in self:
             pipeline.run()
 

--- a/pisa/core/distribution_maker.py
+++ b/pisa/core/distribution_maker.py
@@ -11,7 +11,6 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from collections import OrderedDict
 from collections.abc import Mapping
 import inspect
-from itertools import product
 import os
 from tabulate import tabulate
 
@@ -105,7 +104,10 @@ class DistributionMaker(object):
             if not isinstance(pipeline, Pipeline):
                 pipeline = Pipeline(pipeline, profile=profile)
             else:
-                pipeline.profile = profile
+                if profile:
+                    # Only propagate if set to `True` (don't allow negative
+                    # default to negate any original choice for the instance)
+                    pipeline.profile = profile
             self._pipelines.append(pipeline)
 
         data_run_livetime = None
@@ -217,9 +219,14 @@ class DistributionMaker(object):
     def __iter__(self):
         return iter(self._pipelines)
 
-    def report_profile(self, detailed=False):
+    def report_profile(self, detailed=False, format_num_kwargs=None):
+        """Report timing information on contained pipelines.
+        See `Pipeline.report_profile` for details.
+        """
         for pipeline in self.pipelines:
-            pipeline.report_profile(detailed=detailed)
+            pipeline.report_profile(
+                detailed=detailed, format_num_kwargs=format_num_kwargs
+            )
 
     @property
     def profile(self):
@@ -547,6 +554,22 @@ def test_DistributionMaker():
         #current_hier = new_hier
         #current_mat = new_mat
 
+    # test profile flag
+    p_cfg = 'settings/pipeline/example.cfg'
+    p = Pipeline(p_cfg, profile=True)
+    dm = DistributionMaker(pipelines=p)
+    # default init using Pipeline instance shouldn't negate
+    assert dm.pipelines[0].profile
+    # but explicit request should
+    dm.profile = False
+    assert not dm.pipelines[0].profile
+    # now init from cfg path and request profile
+    dm = DistributionMaker(pipelines=p_cfg, profile=True)
+    assert dm.pipelines[0].profile
+    # explicitly request no profile
+    dm = DistributionMaker(pipelines=p_cfg, profile=False)
+    assert not dm.pipelines[0].profile
+
 
 def parse_args():
     """Get command line arguments"""
@@ -632,4 +655,4 @@ def main(return_outputs=False):
 
 
 if __name__ == '__main__':
-    distribution_maker, outputs = main(return_outputs=True) # pylint: disable=invalid-name
+    distribution_maker, outputs = main(return_outputs=True)

--- a/pisa/core/pipeline.py
+++ b/pisa/core/pipeline.py
@@ -158,6 +158,15 @@ class Pipeline(object):
              Will display each number with three decimal digits by default.
 
         """
+        if not self.profile:
+            # Report warning only at the pipeline level, which is what the
+            # typical user should come across. Assume that users calling
+            # `report_profile` on a `Stage` instance directly know what they're
+            # doing.
+            logging.warn(
+                '`profile` is set to False. Results may not show the expected '
+                'numbers of function calls.'
+            )
         if format_num_kwargs is None:
             format_num_kwargs = {
                 'precision': 1e-3, 'fmt': 'full', 'trailing_zeros': True

--- a/pisa/core/stage.py
+++ b/pisa/core/stage.py
@@ -139,17 +139,20 @@ class Stage():
     def __repr__(self):
         return 'Stage "%s"'%(self.__class__.__name__)
 
-    def report_profile(self, detailed=False):
+    def report_profile(self, detailed=False, **format_num_kwargs):
+        """Report timing information on calls to setup, compute, and apply
+        """
         print(self.stage_name, self.service_name)
-        print('- setup: ', format_times(self.setup_times))
-        if detailed:
-            print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.setup_times)]))
-        print('- calc:  ', format_times(self.calc_times))
-        if detailed:
-            print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.calc_times)]))
-        print('- apply: ', format_times(self.apply_times))
-        if detailed:
-            print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.apply_times)]))
+        for func_str, times in [
+            ('- setup:   ', self.setup_times),
+            ('- compute: ', self.calc_times),
+            ('- apply:   ', self.apply_times)
+        ]:
+            print(func_str,
+                format_times(times=times,
+                             nindent_detailed=len(func_str) + 1,
+                             detailed=detailed, **format_num_kwargs)
+            )
 
     def select_params(self, selections, error_on_missing=False):
         """Apply the `selections` to contained ParamSet.

--- a/pisa/core/stage.py
+++ b/pisa/core/stage.py
@@ -12,6 +12,7 @@ from time import time
 import numpy as np
 
 from pisa.core.container import ContainerSet
+from pisa.utils.format import format_times
 from pisa.utils.log import logging
 from pisa.core.param import ParamSelector
 from pisa.utils.format import arg_str_seq_none
@@ -139,20 +140,14 @@ class Stage():
         return 'Stage "%s"'%(self.__class__.__name__)
 
     def report_profile(self, detailed=False):
-        def format(times):
-            tot = np.sum(times)
-            n = len(times)
-            ave = 0. if n == 0 else tot/n
-            return 'Total time %.5f s, n calls: %i, time/call: %.5f s'%(tot, n, ave)
-
         print(self.stage_name, self.service_name)
-        print('- setup: ', format(self.setup_times))
+        print('- setup: ', format_times(self.setup_times))
         if detailed:
             print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.setup_times)]))
-        print('- calc:  ', format(self.calc_times))
+        print('- calc:  ', format_times(self.calc_times))
         if detailed:
             print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.calc_times)]))
-        print('- apply: ', format(self.apply_times))
+        print('- apply: ', format_times(self.apply_times))
         if detailed:
             print('         Individual runs: ', ', '.join(['%i: %.3f s' % (i, t) for i, t in enumerate(self.apply_times)]))
 

--- a/pisa/stages/utils/kde.py
+++ b/pisa/stages/utils/kde.py
@@ -5,6 +5,7 @@ that represent event counts
 from copy import deepcopy
 
 import numpy as np
+from time import time
 
 from pisa.core.stage import Stage
 from pisa.core.binning import MultiDimBinning, OneDimBinning
@@ -132,11 +133,21 @@ class kde(Stage):  # pylint: disable=invalid-name
 
     @profile
     def apply(self):
-        # this is special, we want the actual event weights in the kde
-        # therefor we're overwritting the apply function
-        # normally in a stage you would implement the `apply_function` method
-        # and not the `apply` method!
+        """This is special, we want the actual event weights in the kde
+        therefor we're overwritting the apply function
+        normally in a stage you would implement the `apply_function` method
+        and not the `apply` method! We also have to reimplement the profiling
+        functionality in apply of the Base class"""
 
+        if self.profile:
+            start_t = time()
+            self.apply_function()
+            end_t = time()
+            self.apply_times.append(end_t - start_t)
+        else:
+            self.apply_function()
+
+    def apply_function(self):
         for container in self.data:
 
             if self.stash_valid:

--- a/pisa/utils/format.py
+++ b/pisa/utils/format.py
@@ -1267,6 +1267,25 @@ def format_num(
     return left_delimiter + num_str + right_delimiter
 
 
+def format_times(times):
+    """Helper function used to report sum and average of times
+    in `times` sequence as well as its length (representing number
+    of calls of some function).
+
+    Parameters
+    ----------
+    times : Sequence
+
+    Returns
+    -------
+    formatted : string
+    """
+    tot = np.sum(times)
+    n = len(times)
+    ave = 0. if n == 0 else tot/n
+    return 'Total time %.5f s, n calls: %i, time/call: %.5f s'%(tot, n, ave)
+
+
 def test_format_num():
     """Unit tests for the `format_num` function"""
     # sci_thresh

--- a/pisa/utils/format.py
+++ b/pisa/utils/format.py
@@ -247,18 +247,22 @@ def split(string, sep=',', force_case=None, parse_func=None):
 
 def arg_str_seq_none(inputs, name):
     """Simple input handler.
+
     Parameters
     ----------
     inputs : None, string, or iterable of strings
         Input value(s) provided by caller
     name : string
         Name of input, used for producing a meaningful error message
+
     Returns
     -------
     inputs : None, or list of strings
+
     Raises
     ------
     TypeError if unrecognized type
+
     """
     if isinstance(inputs, str):
         inputs = [inputs]
@@ -1267,23 +1271,50 @@ def format_num(
     return left_delimiter + num_str + right_delimiter
 
 
-def format_times(times):
-    """Helper function used to report sum and average of times
-    in `times` sequence as well as its length (representing number
-    of calls of some function).
+def format_times(times, nindent_detailed=0, detailed=False, **format_num_kwargs):
+    """Report statistics derived from a sample of run times,
+    whose size may represent the number of calls to some function,
+    using a custom number format.
 
     Parameters
     ----------
-    times : Sequence
+    times : Sequence of float
+        Sequence of run times
+    nindent_detailed : int, optional
+        Number of spaces for indentation of detailed info
+    detailed : bool, default False
+        Whether to output every individual run time also
+    **format_num_kwargs : dict, optional
+        Arguments to `format_num`: refer to its documentation for
+        the list of all possible arguments.
 
     Returns
     -------
-    formatted : string
+    formatted : str
+
     """
+    assert isinstance(times, Sequence)
     tot = np.sum(times)
     n = len(times)
-    ave = 0. if n == 0 else tot/n
-    return 'Total time %.5f s, n calls: %i, time/call: %.5f s'%(tot, n, ave)
+    if n == 0:
+        return 'n calls: 0'
+    ave = format_num(tot/n, **format_num_kwargs)
+    tot = format_num(tot, **format_num_kwargs)
+    max_time = format_num(np.max(times), **format_num_kwargs)
+    min_time = format_num(np.min(times), **format_num_kwargs)
+    formatted = f'Total time (s): {tot}, n calls: {n}'
+    if n > 1:
+        formatted += (
+            f', time/call (s): mean {ave}, max. {max_time}, min. {min_time}'
+        )
+        if detailed:
+            assert isinstance(nindent_detailed, int)
+            formatted += '\n' + ' ' * nindent_detailed + 'Individual runs: '
+            for i, t in enumerate(times):
+                formatted += '%i: %s s, ' % (
+                    i, format_num(t, **format_num_kwargs)
+                )
+    return formatted
 
 
 def test_format_num():


### PR DESCRIPTION
consistently propagate value of `profile` to any contained `Pipeline` instances and enable customisable number format (making use of the very powerful `utils.format.format_num` function).

Note that `Pipeline.get_outputs()`, `Pipeline.setup()`, and `Pipeline.run()` can now be separately profiled, so one does not have to manually add up the timings from the individual services within a pipeline and any overhead from computations  in addition to `Pipeline.run()` becomes visible.

Example output from a call to new `DistributionMaker.report_profile()` with default args:
```
Pipeline: neutrinos
- setup:        Total time (s): 61.584, n calls: 1
- run:          Total time (s): 3.825, n calls: 2, time/call (s): mean 1.913, max. 3.535, min. 0.291
- get_outputs:  Total time (s): 4.080, n calls: 2, time/call (s): mean 2.040, max. 3.547, min. 0.533
Individual services:
data simple_data_loader
- setup:    Total time (s): 0.010, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): 0.017, n calls: 2, time/call (s): mean 0.008, max. 0.011, min. 0.006

....

Pipeline: muons
- setup:        Total time (s): 0.006, n calls: 1
- run:          Total time (s): 2.621, n calls: 2, time/call (s): mean 1.310, max. 2.619, min. 0.001
- get_outputs:  Total time (s): 2.624, n calls: 2, time/call (s): mean 1.312, max. 2.622, min. 0.002
Individual services:
data simple_data_loader
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): +0.000, n calls: 2, time/call (s): mean +0.000, max. +0.000, min. +0.000

...
```

Resolves #815 
