### PR TITLE
Enable (in)equality constraints for use with local and global scipy minimizers

### DIFF
--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -4166,9 +4166,9 @@ def test_global_scipy_minimization(pprint=False):
             "stepsize": 0.1
         }
     }
-    # w/ constraints
+    # basinhopping w/ constraints
     run_global_with_supported_local(method_kwargs, constrs_list, constrs_test)
-    # w/o (skip)
+    # basinhopping w/o (skip)
     #run_global_with_supported_local(method_kwargs)
 
     method_kwargs = {
@@ -4178,17 +4178,39 @@ def test_global_scipy_minimization(pprint=False):
             "seed": 0
         }
     }
-    # w/ constraints
+    # dual annealing w/ constraints
     run_global_with_supported_local(method_kwargs, constrs_list, constrs_test)
-    # w/o (skip)
+    # dual annealing w/o (skip)
     #run_global_with_supported_local(method_kwargs)
 
-    # run with trust-constr (w/ constraints)
+    # DE with trust-constr (w/ constraints)
     run_differential_evolution(constrs_list, constrs_test)
-    # Running with l-bfgs-b (w/o constraints) or without polishing
+    # DE with l-bfgs-b (w/o constraints) or without polishing
     # entirely takes too long:
     #run_differential_evolution(None, None, polish=True)
     #run_differential_evolution(None, None, polish=False)
+
+    def run_global_min_with_constraints_from_file(fit_sett):
+        from pisa.utils.fileio import from_file
+        ana = BasicAnalysis()
+        ana.pprint = pprint
+
+        fit_sett = from_file(fit_sett)
+
+        dm.params.unfix("theta23")
+        dm.reset_free()
+        dm.params.randomize_free(random_state=0)
+        bf = ana.fit_recursively(
+            data_dist=data_dist,
+            hypo_maker=dm,
+            metric="chi2",
+            external_priors_penalty=None,
+            **fit_sett
+        )
+        if not bf.minimizer_metadata['success']:
+            raise RuntimeError("Minimizer unsuccessful")
+
+    #run_global_min_with_constraints_from_file('settings/minimizer/de_2nd_octant_popsize_10_init_sobol_polish_tol1e-1_maxiter1000.json')
 
     logging.info('<< PASS : test_global_scipy_minimization >>')
 

--- a/pisa/analysis/analysis.py
+++ b/pisa/analysis/analysis.py
@@ -3831,7 +3831,7 @@ def test_constrained_minimization(pprint=False):
     data_dist = dm.get_outputs(return_sum=True)
 
     ### slsqp test with constraints ###
-    def test_slsqp_constr():
+    def slsqp_constr():
         ana = BasicAnalysis()
         ana.pprint = pprint
         min_sett = {
@@ -3871,7 +3871,7 @@ def test_constrained_minimization(pprint=False):
         assert bf.params.aeff_scale.m_as('dimensionless') <= max_aeff_scale + tol
 
     ### cobyla test with inequality constraints (doesn't support equalities) ###
-    def test_cobyla_constr():
+    def cobyla_constr():
         ana = BasicAnalysis()
         ana.pprint = pprint
 
@@ -3905,7 +3905,7 @@ def test_constrained_minimization(pprint=False):
         assert bf.params.aeff_scale.m_as('dimensionless') >= min_aeff_scale - tol
 
     ### trust-constr test with constraints ###
-    def test_trust_constr_constr():
+    def trust_constr_constr():
         ana = BasicAnalysis()
         ana.pprint = pprint
 
@@ -3942,7 +3942,7 @@ def test_constrained_minimization(pprint=False):
         assert bf.params.aeff_scale.m_as('dimensionless') <= max_aeff_scale + tol
 
     ### Nelder-Mead test (no constraints supported) ###
-    def test_nm_unconstr():
+    def nm_unconstr():
         ana = BasicAnalysis()
         ana.pprint = pprint
 
@@ -3963,7 +3963,7 @@ def test_constrained_minimization(pprint=False):
         assert bf.minimizer_metadata['success']
 
     ### finally an nlopt solver with constraints ###
-    def test_some_nlopt_constr():
+    def some_nlopt_constr():
         ana = BasicAnalysis()
         ana.pprint = pprint
 
@@ -3999,14 +3999,14 @@ def test_constrained_minimization(pprint=False):
         [dm.params.unfix(p) for p in fix_params] # pylint: disable=expression-not-assigned
 
     # now run them all
-    test_slsqp_constr()
+    slsqp_constr()
     try:
-        test_cobyla_constr()
+        cobyla_constr()
     except Exception as e:
         logging.error("Cobyla test with constraints failed: '%s'. This is under investigation..." % str(e))
-    test_trust_constr_constr()
-    test_nm_unconstr()
-    test_some_nlopt_constr()
+    trust_constr_constr()
+    nm_unconstr()
+    some_nlopt_constr()
 
 if __name__ == "__main__":
     set_verbosity(1)

--- a/pisa_examples/resources/settings/minimizer/de_2nd_octant_popsize_10_init_sobol_polish_tol1e-1_maxiter1000.json
+++ b/pisa_examples/resources/settings/minimizer/de_2nd_octant_popsize_10_init_sobol_polish_tol1e-1_maxiter1000.json
@@ -1,0 +1,18 @@
+{
+  "method": "scipy",
+  "method_kwargs": {
+    "global_method": "differential_evolution",
+    "options": {
+      "maxiter": 1000,
+      "tol": 0.1,
+      "popsize": 10,
+      "init": "sobol",
+      "disp": true,
+      "seed": 0,
+      "constraints": [
+        {"type": "ineq",
+         "fun": "lambda p: p.theta23.m_as('degree') - 45."}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
* also (re)introduce support for a few more scipy minimisers
* redefine `_minimizer_callback` signature to support "trust-constr" minimiser
* add a few quick minimiser tests (with and without constraints)
* minor touchups