### PR TITLE
Make `VarBinning` accept cut variables that are simultaneously part of a `MultiDimBinning`

### DIFF
--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -3095,8 +3095,9 @@ class VarBinning():
             sel_vars_in_mdb = self._selection_vars_in_mdb(b, selections)
             if sel_vars_in_mdb and isinstance(selections, OneDimBinning):
                 raise ValueError(
-                    f"Selection variables {sel_vars_in_mdb} may not"
-                    " simultaneously be part of any MultiDimBinning!"
+                    f"Selection variable {sel_vars_in_mdb[0]}"
+                    " (the OneDimBinning dimension) may not simultaneously be"
+                    " part of any MultiDimBinning!"
                 )
             all_equal = all_equal and b == binnings[0]
 


### PR DESCRIPTION
For context, see last osc. WG call. The corresponding cut expressions could now look as follows:
```
binning.split = (E_reco < 10) & (pid >= 0.4) & (pid < 0.64) , (E_reco >= 10) & (Y < 0.38) & (pid >= 0.4) & (pid < 0.64) , (E_reco >= 10) & (Y >= 0.38) & (pid >= 0.4) & (pid < 0.64), (E_reco < 30) & (pid >= 0.64), (E_reco >= 30) & (Y < 0.32) & (pid >= 0.64), (E_reco >= 30) & (Y >= 0.32) & (pid >= 0.64)
```