### PR TITLE
remove setuptools and pip caps in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ __license__ = '''Copyright (c) 2014-2025, The IceCube Collaboration
 
 SETUP_REQUIRES = [
     'pip>=1.8,<21.3',
-    'setuptools>18.5,<60.0', # versioneer requires >18.5
+    'setuptools>18.5', # versioneer requires >18.5
     'numpy>=1.17,<1.23',
     'scipy>=1.6,<1.14',
     'cython~=0.29.0', # needed for the setup and for the install

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ __license__ = '''Copyright (c) 2014-2025, The IceCube Collaboration
 
 
 SETUP_REQUIRES = [
-    'pip>=1.8,<21.3',
+    'pip>=1.8',
     'setuptools>18.5', # versioneer requires >18.5
     'numpy>=1.17,<1.23',
     'scipy>=1.6,<1.14',


### PR DESCRIPTION
It turns out that the setuptools cap causes (at least) the most recent miniforge install to fail (pip 25.1.1, setuptools 80.8.0) and is unnecessary for the two supported installation methods anyway (tested with mentioned pip as well as with 24.3.1 and with pip 21.2.4 + setuptools 58.1.0 in cvmfs install). The pip cap is irrelevant.