### PR TITLE
Remove cap and explicit pip install from workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,21 +13,20 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        python -m pip install "pip<21.3"
         pip install .[develop]
     - name: Build the docs
       run: |
         sphinx-apidoc -f -o docs/source pisa
         cd docs && make html
     - name: Deploy to gh pages
-      uses: peaceiris/actions-gh-pages@v3.9.2
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install "pip<21.3"
         pip install .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          python -m pip install "pip<21.3"
           pip install setuptools wheel build
           pip install .
       - name: Build package


### PR DESCRIPTION
Testing whether we can remove the cap from the workflow also.

- python 3.10 workflow: a recent pip install (25.1.1.) is available already on the host.
- python 3.8 workflow: pip 25.0.1. is simultaneously installed.

As expected, this runs through successfully. If we merge this PR, the pip version with which PISA is installed will not be frozen any longer. This might serve as a convenient monitoring tool and provide an incentive to modernise the setup procedure eventually.

Edit: also took the opportunity to update the other two workflows (we will only know whether they work when pushed to master (documentation.yml) respectively a new release is created (release.yml)).