### PR TITLE
make CSV loader compatible with older data releases

### DIFF
--- a/pisa/stages/data/csv_loader.py
+++ b/pisa/stages/data/csv_loader.py
@@ -130,7 +130,7 @@ class csv_loader(Stage):  # pylint: disable=invalid-name
                     raise ValueError("Either 'pdg' or 'pdg_code' must be in file.")
 
                 if 'cc' in name:
-                    mask = np.logical_and(mask, raw_data['type'] == 1)
+                    mask = np.logical_and(mask, raw_data['type'] >= 1)
                 else:
                     mask = np.logical_and(mask, raw_data['type'] == 0)
 


### PR DESCRIPTION
In the old data releases, the field "type" not only differentiated between 0 = NC and 1 = CC, but it encoded the various CC interaction types with numbers > 0 (1, 2, 3, ...).