### PR TITLE
Add Dependabot configuration (pip + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"                    # setup.py and setup.cfg are in repository root
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      # optional: specifying time in UTC (format HH:MM). Uncomment to set a preferred time.
+      # time: "04:00"
+    open-pull-requests-limit: 5
+    # Dependabot will attempt to parse setup.py / setup.cfg; it also supports requirements.txt if added.
+    allow:
+      - dependency-type: "direct"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"   # workflows live under .github/workflows
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
I propose testing if and how Dependabot can help us with our dependency updates. The suggested file has been produced using copilot. Once it is merged, we should be able to trigger a manual first Dependabot run from the dependency graph.
  
* Adds .github/dependabot.yml to enable Dependabot version updates for pip (setup.py/setup.cfg) and GitHub Actions workflows.
* Schedule: weekly
* Notes: Git-based dependencies (VCS URLs) and conda environment files are not managed by Dependabot (need pinned requirements or pyproject.toml for improved updates)