### PR TITLE
Update cython, simplejson, scikit-learn

### DIFF
--- a/pisa/utils/llh_defs/poisson_gamma_mixtures.pyx
+++ b/pisa/utils/llh_defs/poisson_gamma_mixtures.pyx
@@ -43,7 +43,7 @@ def c_single_pgg(int k, double A,double B, double Q, double kmc, double gamma, n
 
     cdef double res=0.0
     if((log_sterlings.shape[0]-1)<k):
-        print "sterling matrix too small .. requires at least k+1, k is ..", k
+        print("sterling matrix too small .. requires at least k+1, k is ..", k)
         sys.exit(-1)
    
     single_pgg(k, A, B, Q, kmc, gamma, <double*> log_sterlings.data, int(log_sterlings.shape[0]), &res)
@@ -55,7 +55,7 @@ def c_multi_pgg(int k, np.ndarray[np.float64_t, ndim=1] A,np.ndarray[np.float64_
 
     cdef double res=0.0
     if((log_sterlings.shape[0]-1)<k):
-        print "sterling matrix too small .. requires at least k+1, k is ..", k
+        print("sterling matrix too small .. requires at least k+1, k is ..", k)
         sys.exit(-1)
    
     multi_pgg(k, <double*> A.data, <double*> B.data, <double*> Q.data, <double*> kmc.data, <double*> gamma.data, int(A.shape[0]), <double*> log_sterlings.data, int(log_sterlings.shape[0]),  &res)

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,7 @@ SETUP_REQUIRES = [
     'setuptools>18.5', # versioneer requires >18.5
     'numpy>=1.17,<1.23',
     'scipy>=1.6,<1.14',
-    'cython~=0.29.0', # needed for the setup and for the install
-    'scikit-learn<=1.1.2',
+    'cython',
 ]
 
 INSTALL_REQUIRES = [
@@ -98,15 +97,15 @@ INSTALL_REQUIRES = [
     'pint<=0.19', # property pint.quantity._Quantity no longer exists in 0.20
     'scipy>=1.6,<1.14',
     'pandas',
-    'simplejson==3.18.4',
+    'simplejson>=3.19.1', # allow_nan added to decoder
     'tables',
     'tabulate',
     'uncertainties',
     'llvmlite', # 0.31 gave an error "Type of #4 arg mismatch: i1 != i32" in pisa/stages/osc/layers.py", line 91
     'py-cpuinfo',
     'sympy',
-    'cython~=0.29.0', # needed for the setup and for the install
-    'scikit-learn<=1.1.2',
+    'cython',
+    'scikit-learn',
     'pyarrow',
     'tqdm',
     'daemonflux>=0.8.0',


### PR DESCRIPTION
* resolves #896 
* resolves #897 
* resolves #898 

Note that there is currently a different definition of the NumpyDecoder depending on which version of simplejson is detected. This should prevent this PR from breaking existing installations (I ran the unit tests on this branch with an existing python 3.10 installation and they succeeded).