### PR TITLE
Remove setuptools cap in build-time dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ __license__ = '''Copyright (c) 2014-2026, The IceCube Collaboration
 
 SETUP_REQUIRES = [
     'pip>=1.8',
-    'setuptools>18.5,<81', # versioneer requires >18.5, use of pkg_resources requires <81
+    'setuptools>18.5', # versioneer requires >18.5
     'numpy>=1.17',
     'scipy>=1.6',
     'cython',


### PR DESCRIPTION
... as it was unnecessary (and caused problems now that [versions 81 and 82 have been released](https://setuptools.pypa.io/en/stable/history.html), see e.g. https://github.com/icecube/pisa/actions/runs/21874474802/job/63139185283).