### PR TITLE
generalized_llh_params service: assign 0th and only element to beta & trad_alpha instead of length-1 array

### DIFF
--- a/pisa/stages/likelihood/generalized_llh_params.py
+++ b/pisa/stages/likelihood/generalized_llh_params.py
@@ -237,8 +237,8 @@ class generalized_llh_params(Stage):  # pylint: disable=invalid-name
                 # default to alphas values of PSEUDO_WEIGHT and
                 # of beta = 1.0, which mimicks a narrow PDF
                 # close to 0.0
-                beta = np.divide(mean_w, var_z, out=np.ones(1), where=var_z!=0)
-                trad_alpha = np.divide(mean_w**2, var_z, out=np.ones(1)*PSEUDO_WEIGHT, where=var_z!=0)
+                beta = np.divide(mean_w, var_z, out=np.ones(1), where=var_z!=0)[0]
+                trad_alpha = np.divide(mean_w**2, var_z, out=np.ones(1)*PSEUDO_WEIGHT, where=var_z!=0)[0]
                 alpha = (n_weights + mean_adjustment)*trad_alpha
 
                 alphas_vector[index] = alpha


### PR DESCRIPTION
Fixes #911.

The reason for the recently observed failures with numpy 2.4.2 must be [this expired deprecation](https://github.com/numpy/numpy/pull/29841), as specified in the [release notes of numpy 2.4.0](https://github.com/numpy/numpy/releases/tag/v2.4.0).
