### PR TITLE
Add fast workflow for building PISA docker image and publishing to GitHub packages

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,60 @@
+# Workflow adapted from https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages
+name: Create and publish a Docker image
+
+# Run when a release is created or when triggered manually
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+# Two custom environment variables for the workflow, which are used for the Container registry domain (here: GitHub packages), and a name for the Docker image
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Docker Login
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path.
+      # For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image.
+      # For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest@v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
-# Use the official condaforge base image
-FROM condaforge/miniforge3:latest
+# Dockerfile for an image which includes a PISA installation through the fast uv Python package manager.
+# This image is based on a "slimmified" Debian 13 image.
 
-# Install gcc
-RUN apt-get update && apt-get install -y gcc
+# Docker: https://docs.docker.com/get-started/docker-concepts/building-images/
+# uv: https://github.com/astral-sh/uv
 
-# Change python version to 3.10
-RUN conda install python=3.10
+FROM debian:trixie-slim
 
-# Set pisa path
-ENV PISA=pisa/
+# Install curl (for uv installer) & git + gcc (for building PISA) & uv from standalone installer
+RUN apt-get update && apt-get install -y gcc curl git && curl -Lf https://astral.sh/uv/install.sh | sh
 
-# Create pisa folder
+# Add executable to path and set PISA path
+ENV PATH=/root/.local/bin/:$PATH PISA=pisa/
+
+# Create PISA source folder
 RUN mkdir -p $PISA
 
 # Link pisa folder
-ADD . $PISA
+COPY . $PISA
 
-# Install pisa
-RUN pip install -e $PISA
-
-# Install Jupyter notebook
-RUN pip install notebook
+# Create virtual env. with Python 3.12, activate it, and install PISA (non-editable is important with uv here) + jupyter notebook
+RUN uv venv --python 3.12 .venv && . .venv/bin/activate && uv pip install $PISA && uv pip install notebook
 
 # Expose the Jupyter server port
 EXPOSE 8888

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ outputs['nutau_cc'].plot(ax=axes[2], cmap='RdYlBu_r', vmin=0, vmax=1);
 
 # Containerization
 
-PISA includes a [Dockerfile](Dockerfile) that can be used to containerize the software (e.g. with docker or singularity). More information on how to do this can be found [here](https://github.com/icecube/wg-oscillations-fridge/blob/master/docs/CONTAINER_INSTRUCTIONS.md) (access restricted).
+In case you do not want to install PISA, we provide pre-built [Docker](https://docs.docker.com) images [here](https://github.com/orgs/icecube/packages?repo_name=pisa). You can download a given image via `docker pull ghcr.io/icecube/pisa:<tag>`, where `<tag>` has to be replaced by the desired release tag or `master`. Each image is built using the [Dockerfile](Dockerfile) included in PISA.
+You can also use it to containerize PISA yourself (with Docker or [Singularity](https://docs.sylabs.io/guides/latest/user-guide/). Instructions can be found [here](https://github.com/icecube/wg-oscillations-fridge/blob/master/docs/CONTAINER_INSTRUCTIONS.md) (access restricted).
 
 # Contributions
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ outputs['nutau_cc'].plot(ax=axes[2], cmap='RdYlBu_r', vmin=0, vmax=1);
 # Containerization
 
 In case you do not want to install PISA, we provide pre-built [Docker](https://docs.docker.com) images [here](https://github.com/orgs/icecube/packages?repo_name=pisa). You can download a given image via `docker pull ghcr.io/icecube/pisa:<tag>`, where `<tag>` has to be replaced by the desired release tag or `master`. Each image is built using the [Dockerfile](Dockerfile) included in PISA.
-You can also use it to containerize PISA yourself (with Docker or [Singularity](https://docs.sylabs.io/guides/latest/user-guide/). Instructions can be found [here](https://github.com/icecube/wg-oscillations-fridge/blob/master/docs/CONTAINER_INSTRUCTIONS.md) (access restricted).
+You can also use it to containerize PISA yourself (with Docker or [Singularity](https://docs.sylabs.io/guides/latest/user-guide/)). Instructions can be found [here](https://github.com/icecube/wg-oscillations-fridge/blob/master/docs/CONTAINER_INSTRUCTIONS.md) (access restricted).
 
 # Contributions
 


### PR DESCRIPTION
Note that the dockerfile uses [uv](https://github.com/astral-sh/uv) instead of conda, which cuts down the image build duration to approx. 1/3 (3 mins.) - even faster than if we replaced conda by mamba. Also, the resulting image is roughly only half as large (1.75 GB) as the one produced by the current dockerfile.

I have tested the general setup with this workflow + dockerfile in my repo, downloaded the image via `docker pull`, and started a container.

Here, the image from a _manual_ workflow dispatch would have to be downloaded via the command  `docker pull ghcr.io/icecube/pisa:master` if I'm not mistaken. When triggered by a release, master should be replaced by the corresponding release tag.