### PR TITLE
Granular control of PISA fast-histogram threading and more robust numba thread setup

### DIFF
--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -257,8 +257,8 @@ if 'PISA_HIST_THREADING' in os.environ:
     else:
         try:
             PISA_HIST_THREADING = int(pisa_hist_threading) # pylint: disable=invalid-name
-            if PISA_HIST_THREADING < 0:
-                raise ValueError('must be >= 0')
+            if PISA_HIST_THREADING <= 0:
+                raise ValueError('must be > 0')
         except ValueError as exc:
             raise ValueError(
                 f'Environment variable PISA_HIST_THREADING="{pisa_hist_threading}" '

--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -242,12 +242,14 @@ OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
 
 PISA_HIST_THREADING = 'off' # pylint: disable=invalid-name
 """Granular control of strategy for threading in PISA (fast-)histogram operations.
-choices:
-  - 'off' (default): Disable threading completely (as it adds significant
-    overhead to typical applications).
-  - 'auto': Use PISA_NUM_THREADS when TARGET='parallel', else no threading
-  - N (integer > 0): Use N threads for histogram operations regardless of TARGET
-Set via PISA_HIST_THREADING environment variable"""
+Choices:
+
+- 'off' (default): Disable threading completely (as it adds significant
+  overhead to typical applications).
+- 'auto': Use :py:data:`PISA_NUM_THREADS` when `TARGET='parallel'`, else no threading.
+- N (integer > 0): Use N threads for histogram operations regardless of `TARGET`.
+
+Set via `PISA_HIST_THREADING` environment variable."""
 
 if 'PISA_HIST_THREADING' in os.environ:
     pisa_hist_threading = os.environ['PISA_HIST_THREADING'].strip().lower()

--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -240,13 +240,14 @@ numba.set_num_threads(PISA_NUM_THREADS)
 # final choice for OpenMP number of threads
 OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
 
-PISA_HIST_THREADING = 'auto' # pylint: disable=invalid-name
-"""Granular control of strategy for threading in histogram operations.
+PISA_HIST_THREADING = 'off' # pylint: disable=invalid-name
+"""Granular control of strategy for threading in PISA (fast-)histogram operations.
 choices:
-  - 'auto' (default): use PISA_NUM_THREADS when TARGET='parallel', else no threading
-  - 'off': disable threading completely
-  - N (integer > 0): use N threads for histogram operations regardless of TARGET
-Set via PISA_HIST_THREADING env var"""
+  - 'off' (default): Disable threading completely (as it adds significant
+    overhead to typical applications).
+  - 'auto': Use PISA_NUM_THREADS when TARGET='parallel', else no threading
+  - N (integer > 0): Use N threads for histogram operations regardless of TARGET
+Set via PISA_HIST_THREADING environment variable"""
 
 if 'PISA_HIST_THREADING' in os.environ:
     pisa_hist_threading = os.environ['PISA_HIST_THREADING'].strip().lower()

--- a/pisa/__init__.py
+++ b/pisa/__init__.py
@@ -70,6 +70,7 @@ __all__ = [
     'TARGET',
     'OMP_NUM_THREADS',
     'PISA_NUM_THREADS',
+    'PISA_HIST_THREADING',
     'FTYPE',
     'CTYPE',
     'ITYPE',
@@ -85,10 +86,10 @@ __version__ = get_versions()['version']
 """PISA version is automatically constructed from versioneer/git info"""
 
 
-ureg = UnitRegistry() # pylint: disable=invalid-name
+ureg = UnitRegistry()
 """Single Pint unit registry that should be used by all PISA code"""
 
-Q_ = ureg.Quantity # pylint: disable=invalid-name
+Q_ = ureg.Quantity
 """Shortcut for Quantity that uses central PISA Pint unit regeistry"""
 
 
@@ -97,7 +98,7 @@ CACHE_DIR = '~/.cache/pisa'
 """Root directory for storing PISA cache files"""
 
 # message later on written to stderr for user convenience
-ini_msgs = [] # pylint: disable=invalid-name
+ini_msgs = []
 
 # PISA users can define cache directory directly via PISA_CACHE_DIR env var;
 # PISA_CACHE_DIR has priority over XDG_CACHE_HOME, so it is checked first
@@ -127,19 +128,19 @@ if 'OMP_NUM_THREADS' in os.environ:
     OMP_NUM_THREADS = int(os.environ['OMP_NUM_THREADS'])
     assert OMP_NUM_THREADS >= 1
 
-NUMBA_CUDA_AVAIL = False
+NUMBA_CUDA_AVAIL = False # pylint: disable=invalid-name
 def dummy_func(x):
     """Decorate to to see if Numba actually works"""
     x += 1
 
 try:
-    from numba import cuda
+    from numba import cuda # pylint: disable=ungrouped-imports
     assert cuda.gpus, 'No GPUs detected'
     cuda.jit('void(float64)')(dummy_func)
 except Exception:
     pass
 else:
-    NUMBA_CUDA_AVAIL = True
+    NUMBA_CUDA_AVAIL = True # pylint: disable=invalid-name
 finally:
     if 'cuda' in globals() or 'cuda' in locals():
         #if NUMBA_CUDA_AVAIL:
@@ -179,19 +180,19 @@ ITYPE = np.int32 if FTYPE == np.float32 else np.int64
 del FLOAT32_STRINGS, FLOAT64_STRINGS
 
 # set default target
-TARGET = 'cpu'
+TARGET = 'cpu' # pylint: disable=invalid-name
 
-cpu_targets = ['cpu', 'numba'] # pylint: disable=invalid-name
-parallel_targets = ['parallel', 'multicore'] # pylint: disable=invalid-name
-gpu_targets = ['cuda', 'gpu', 'numba-cuda'] # pylint: disable=invalid-name
+cpu_targets = ['cpu', 'numba']
+parallel_targets = ['parallel', 'multicore']
+gpu_targets = ['cuda', 'gpu', 'numba-cuda']
 
 if 'PISA_TARGET' in os.environ:
     PISA_TARGET = os.environ['PISA_TARGET']
     ini_msgs.append('PISA_TARGET env var is defined as: "%s"' % PISA_TARGET)
-    try_target = PISA_TARGET.strip().lower() # pylint: disable=invalid-name
+    try_target = PISA_TARGET.strip().lower()
     if try_target in gpu_targets:
         if NUMBA_CUDA_AVAIL:
-            TARGET = 'cuda'
+            TARGET = 'cuda' # pylint: disable=invalid-name
         else:
             raise ValueError(
                 'Environment var PISA_TARGET="%s" set, even though numba-cuda'
@@ -199,9 +200,9 @@ if 'PISA_TARGET' in os.environ:
             )
     elif try_target in cpu_targets or try_target in parallel_targets:
         if try_target in cpu_targets:
-            TARGET = 'cpu'
+            TARGET = 'cpu' # pylint: disable=invalid-name
         elif try_target in parallel_targets:
-            TARGET = 'parallel'
+            TARGET = 'parallel' # pylint: disable=invalid-name
     else:
         raise ValueError(
             'Environment var PISA_TARGET="%s" is unrecognized.\n'
@@ -226,24 +227,56 @@ if 'PISA_NUM_THREADS' in os.environ:
                          "PISA_TARGET is not `parallel`.\n")
         PISA_NUM_THREADS = 1
 elif TARGET == 'parallel':
-    PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS
+    PISA_NUM_THREADS = numba.config.NUMBA_NUM_THREADS # pylint: disable=no-member
 
 if TARGET == 'cpu':
     # making sure that we can definitely rely on the fact that the number of threads
     # will be 1 if the TARGET is `cpu` (some stages might do that)
     assert PISA_NUM_THREADS == 1
 
+# initialize numba thread count immediately
+numba.set_num_threads(PISA_NUM_THREADS)
+
+# final choice for OpenMP number of threads
 OMP_NUM_THREADS = min(PISA_NUM_THREADS, OMP_NUM_THREADS)
+
+PISA_HIST_THREADING = 'auto' # pylint: disable=invalid-name
+"""Granular control of strategy for threading in histogram operations.
+choices:
+  - 'auto' (default): use PISA_NUM_THREADS when TARGET='parallel', else no threading
+  - 'off': disable threading completely
+  - N (integer > 0): use N threads for histogram operations regardless of TARGET
+Set via PISA_HIST_THREADING env var"""
+
+if 'PISA_HIST_THREADING' in os.environ:
+    pisa_hist_threading = os.environ['PISA_HIST_THREADING'].strip().lower()
+    if pisa_hist_threading in ('auto', ''):
+        PISA_HIST_THREADING = 'auto' # pylint: disable=invalid-name
+    elif pisa_hist_threading == '0' or pisa_hist_threading in ('false', 'off', 'no'):
+        PISA_HIST_THREADING = 'off' # pylint: disable=invalid-name
+    else:
+        try:
+            PISA_HIST_THREADING = int(pisa_hist_threading) # pylint: disable=invalid-name
+            if PISA_HIST_THREADING < 0:
+                raise ValueError('must be >= 0')
+        except ValueError as exc:
+            raise ValueError(
+                f'Environment variable PISA_HIST_THREADING="{pisa_hist_threading}" '
+                'unrecognized:\n'
+                '  For "auto" mode (PISA_NUM_THREADS) set to "auto" or empty string.\n'
+                '  To disable histogram threading set to "0", "false", "no", or "off".\n'
+                '  For N threads (precedence over PISA_NUM_THREADS) set to integer > 0.'
+            ) from exc
 
 # Define HASH_SIGFIGS to set hashing precision based on FTYPE above; value here
 # is default (i.e. for FTYPE == np.float64)
-HASH_SIGFIGS = 12
+HASH_SIGFIGS = 12 # pylint: disable=invalid-name
 """Round to this many significant figures for hashing numbers, such that
 machine precision doesn't cause effectively equivalent numbers to hash
 differently."""
 
 if FTYPE == np.float32:
-    HASH_SIGFIGS = 5
+    HASH_SIGFIGS = 5 # pylint: disable=invalid-name
 
 EPSILON = 10**(-HASH_SIGFIGS)
 """Best precision considering HASH_SIGFIGS (which is chosen kinda ad-hoc but
@@ -278,7 +311,7 @@ elif FTYPE == np.float64:
     ftype_msg = 'PISA is running in double precision (FP64) mode' # pylint: disable=invalid-name
 else:
     raise ValueError('FTYPE must be one of `np.float32` or `np.float64`. Got'
-                     ' %s instead.' %FTYPE)
+                     f' {FTYPE} instead.')
 ini_msgs.append(ftype_msg)
 del ftype_msg
 
@@ -290,8 +323,20 @@ elif TARGET == 'parallel':
     target_msg = f'numba is running on CPU (multicore) with {PISA_NUM_THREADS} cores' # pylint: disable=invalid-name
 elif TARGET == 'cuda':
     target_msg = 'numba is running on GPU' # pylint: disable=invalid-name
+else:
+    raise ValueError('TARGET must be one of `None`, "cpu", "parallel", or "cuda".'
+                     f' Got {TARGET} instead.')
 ini_msgs.append(target_msg)
 del target_msg
+
+if PISA_HIST_THREADING == 'auto':
+    hist_threading_msg = 'PISA histogram threading is in auto mode (PISA_NUM_THREADS)' # pylint: disable=invalid-name
+elif PISA_HIST_THREADING == 'off':
+    hist_threading_msg = 'PISA histogram threading is disabled' # pylint: disable=invalid-name
+else:
+    hist_threading_msg = f'PISA histogram threading will use {PISA_HIST_THREADING} thread(s)' # pylint: disable=invalid-name
+ini_msgs.append(hist_threading_msg)
+del hist_threading_msg
 
 sys.stderr.write("<< "+"; ".join(ini_msgs)+" >>\n")
 del ini_msgs

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -16,8 +16,6 @@ from copy import deepcopy
 
 import numpy as np
 from numba import guvectorize
-
-import numba
 from numba import njit, prange
 # When binnings are fully regular, we can use this for super speed
 import fast_histogram as fh
@@ -30,8 +28,7 @@ from pisa.core.binning import OneDimBinning, MultiDimBinning
 from pisa.utils.comparisons import recursiveEquality
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.numba_tools import myjit
-from pisa.utils import vectorizer
-from pisa.utils.profiler import line_profile, profile
+from pisa.utils.profiler import profile
 
 __all__ = [
     'resample',
@@ -141,10 +138,11 @@ def _threaded_fh_histogramdd(sample, weights, bins, bin_range):
         # Auto mode: use threading only for parallel TARGET
         if TARGET == 'parallel':
             splits = PISA_NUM_THREADS
-    elif PISA_HIST_THREADING > 0:
+    elif PISA_HIST_THREADING == 'off':
+        pass # splits stays None (disabled)
+    else:
         # Explicit thread count (takes precedence)
-        splits = PISA_HIST_THREADING
-    # else: PISA_HIST_THREADING == 'off' -> splits stays None (disabled)
+        splits = PISA_HIST_THREADING # int > 0
 
     if splits is None or splits < 2:
         return fh.histogramdd(sample=sample, weights=weights, bins=bins,

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable
 
 from concurrent.futures import ThreadPoolExecutor
 
-from pisa import FTYPE, TARGET, PISA_NUM_THREADS
+from pisa import FTYPE, TARGET, PISA_NUM_THREADS, PISA_HIST_THREADING
 from pisa.core.binning import OneDimBinning, MultiDimBinning
 from pisa.utils.comparisons import recursiveEquality
 from pisa.utils.log import logging, set_verbosity
@@ -132,10 +132,23 @@ def histogram(sample, weights, binning, averaged, apply_weights=True):
     return flat_hist
 
 def _threaded_fh_histogramdd(sample, weights, bins, bin_range):
-    if not TARGET == "parallel":
-        return fh.histogramdd(sample=sample, weights=weights, bins=bins, range=bin_range)
+    """Conditionally apply histogram threading based on PISA_HIST_THREADING
+    setting.
+    """
+    # Determine number of splits
+    splits = None
+    if PISA_HIST_THREADING == 'auto':
+        # Auto mode: use threading only for parallel TARGET
+        if TARGET == 'parallel':
+            splits = PISA_NUM_THREADS
+    elif PISA_HIST_THREADING > 0:
+        # Explicit thread count (takes precedence)
+        splits = PISA_HIST_THREADING
+    # else: PISA_HIST_THREADING == 'off' -> splits stays None (disabled)
 
-    splits = PISA_NUM_THREADS
+    if splits is None or splits < 2:
+        return fh.histogramdd(sample=sample, weights=weights, bins=bins,
+                              range=bin_range)
 
     with ThreadPoolExecutor(max_workers=splits) as pool:
         chunk = len(sample[0]) // splits

--- a/pisa/stages/GLOBALS.md
+++ b/pisa/stages/GLOBALS.md
@@ -9,18 +9,19 @@ Here we keep track of which global constants are available, what their purpose i
 
 | Constant           | Description                                                               | Default                                                               | Overwritten by environment variables (priority indicated where necessary) |
 | ------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `NUMBA_CUDA_AVAIL` | Availability of Numba's CUDA interface                                    | `False` (unless CUDA-capable GPU available)                           |                                                                           |
-| `TARGET`           | Numba compilation target                                                  | `cpu`                                                                 | `PISA_TARGET` (GPU target only possible if `NUMBA_CUDA_AVAIL`)                                                              |
-| `OMP_NUM_THREADS`  | Number of threads allocated to OpenMP                                     | `1`                                                                   | `OMP_NUM_THREADS`                                                         |
-| `PISA_NUM_THREADS` | Global limit for number of threads (also upper limit for `OMP_NUM_THREADS`) | `1` (`numba.config.NUMBA_NUM_THREADS`) for `TARGET='cpu'` (`'parallel'`) | `PISA_NUM_THREADS`                                                         |
-| `FTYPE`            | Global floating-point data type                                           | `np.float64`                                                          | `PISA_FTYPE`                                                              |
-| `CTYPE`            | Global complex-valued floating-point data type                            | `np.complex128` (`np.complex64`) for `FTYPE=np.float64(32)`            |                                                                  |
-| `ITYPE`            | Global integer data type                                                  | `np.int64` (`np.int32`) for `FTYPE=np.float64(32)`                    |                                                                  |
-| `HASH_SIGFIGS`     | Number of significant digits used for hashing numbers, depends on `FTYPE` | `12(5)` for `FTYPE=np.float64(32)`                                    |                                                                           |
-| `EPSILON`          | Best numerical precision, derived from `HASH_SIGFIGS`                     | `10**(-HASH_SIGFIGS)`                                                 |                                                                           |
-| `C_FTYPE`          | C floating-point type corresponding to `FTYPE`                            | `'double'` (`'float'`) for `FTYPE=np.float64(32)`                       |                                                                           |
-| `C_PRECISION_DEF`  | C precision of floating-point calculations, derived from `FTYPE`          | `'DOUBLE_PRECISION'` (`'SINGLE_PRECISION'`) for `FTYPE=np.float64(32)`   |                                                                           |
-| `CACHE_DIR`        | Root directory for storing PISA cache files                               | `'~/.cache/pisa'`                                                     | 1.`PISA_CACHE_DIR`, 2.`XDG_CACHE_HOME/pisa`                               |
+| `NUMBA_CUDA_AVAIL`    | Availability of Numba's CUDA interface                                    | `False` (unless CUDA-capable GPU available)                           |                                                                           |
+| `TARGET`              | Numba compilation target                                                  | `cpu`                                                                 | `PISA_TARGET` (GPU target only possible if `NUMBA_CUDA_AVAIL`)                                                              |
+| `OMP_NUM_THREADS`     | Number of threads allocated to OpenMP                                     | `1`                                                                   | `OMP_NUM_THREADS`                                                         |
+| `PISA_NUM_THREADS`    | Global limit for number of threads (also upper limit for `OMP_NUM_THREADS`) | `1` (`numba.config.NUMBA_NUM_THREADS`) for `TARGET='cpu'` (`'parallel'`) | `PISA_NUM_THREADS`                                                         |
+| `PISA_HIST_THREADING` | Multi-threading mode for PISA (fast) histogramming                        | `'off'`                                                               | `PISA_HIST_THREADING`                                                         |
+| `FTYPE`               | Global floating-point data type                                           | `np.float64`                                                          | `PISA_FTYPE`                                                              |
+| `CTYPE`               | Global complex-valued floating-point data type                            | `np.complex128` (`np.complex64`) for `FTYPE=np.float64(32)`           |                                                                  |
+| `ITYPE`               | Global integer data type                                                  | `np.int64` (`np.int32`) for `FTYPE=np.float64(32)`                    |                                                                  |
+| `HASH_SIGFIGS`        | Number of significant digits used for hashing numbers, depends on `FTYPE` | `12(5)` for `FTYPE=np.float64(32)`                                    |                                                                           |
+| `EPSILON`             | Best numerical precision, derived from `HASH_SIGFIGS`                     | `10**(-HASH_SIGFIGS)`                                                 |                                                                           |
+| `C_FTYPE`             | C floating-point type corresponding to `FTYPE`                            | `'double'` (`'float'`) for `FTYPE=np.float64(32)`                     |                                                                           |
+| `C_PRECISION_DEF`     | C precision of floating-point calculations, derived from `FTYPE`          | `'DOUBLE_PRECISION'` (`'SINGLE_PRECISION'`) for `FTYPE=np.float64(32)`|                                                                           |
+| `CACHE_DIR`           | Root directory for storing PISA cache files                               | `'~/.cache/pisa'`                                                     | 1.`PISA_CACHE_DIR`, 2.`XDG_CACHE_HOME/pisa`                               |
 
 ## Usage
 The table below depicts which services make use of a select set of global constants.
@@ -32,51 +33,52 @@ Also note that where a service implements `FTYPE` and relies on C extension code
 - :heavy_check_mark:: implements
 - :heavy_minus_sign:: does not implement but does not fail (i.e., ignores)
 
-|                            | `TARGET`    | `PISA_NUM_THREADS`     | `FTYPE`               |
-| :------------------------: | :-------------------: | :-------------------: | :-------------------: |
-| `absorption.earth_absorption` | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `aeff.aeff`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `aeff.weight`                 | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `aeff.weight_hnl`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `background.atm_muons`        | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `data.csv_data_hist`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.csv_icc_hist`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.csv_loader`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.freedom_hdf5_loader`    | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.grid`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.licloader_weighter`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.meows_loader`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.simple_data_loader`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.simple_signal`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.sqlite_loader`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `data.toy_event_generator`    | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark: |
-| `discr_sys.hypersurfaces`     | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    |
-| `discr_sys.ultrasurfaces`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.airs`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.astrophysical`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.barr_simple`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `flux.daemon_flux`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.hillasg`                | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.honda_ip`               | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `flux.mceq_barr`              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `flux.mceq_barr_red`          | :heavy_check_mark:    | :heavy_minus_sign: | :heavy_check_mark:    |
-| `likelihood.generalized_llh_params`   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `osc.decoherence`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `osc.globes`                  | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `osc.nusquids`                | :heavy_minus_sign:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `osc.prob3`                   | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `osc.two_nu_osc`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `reco.resolutions`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `reco.simple_param`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: |
-| `utils.add_indices`           | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    |
-| `utils.adhoc_sys`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    |
-| `utils.bootstrap`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    |
-| `utils.fix_error`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    |
-| `utils.hist`                  | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    |
-| `utils.kde`                   | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    |
-| `utils.kfold`                 | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    |
-| `utils.resample`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `utils.set_variance`          | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
-| `xsec.dis_sys`                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `xsec.genie_sys`              | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    |
-| `xsec.nutau_xsec`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    |
+|                            | `TARGET`    | `PISA_NUM_THREADS`     | `FTYPE`               | `PISA_HIST_THREADING` |
+| :------------------------: | :-------------------: | :-------------------: | :-------------------: | :-------------------: |
+| `absorption.earth_absorption` | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `aeff.aeff`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| `aeff.weight`                 | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| `aeff.weight_hnl`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| `background.atm_muons`        | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| `cont_sys.snowstorm_hist`     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| `data.csv_data_hist`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.csv_icc_hist`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.csv_loader`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.freedom_hdf5_loader`    | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.grid`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.licloader_weighter`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.meows_loader`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.simple_data_loader`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.simple_signal`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.sqlite_loader`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `data.toy_event_generator`    | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `discr_sys.hypersurfaces`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `discr_sys.ultrasurfaces`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.airs`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.astrophysical`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.barr_simple`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.daemon_flux`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.hillasg`                | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.honda_ip`               | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.mceq_barr`              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| `flux.mceq_barr_red`          | :heavy_check_mark: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `likelihood.generalized_llh_params`   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `osc.decoherence`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `osc.globes`                  | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `osc.nusquids`                | :heavy_minus_sign:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `osc.prob3`                   | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `osc.two_nu_osc`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `reco.resolutions`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| `reco.simple_param`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
+| `utils.add_indices`           | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
+| `utils.adhoc_sys`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `utils.bootstrap`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
+| `utils.fix_error`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `utils.hist`                  | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark: |
+| `utils.kde`                   | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
+| `utils.kfold`                 | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `utils.resample`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `utils.set_variance`          | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+| `xsec.dis_sys`                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| `xsec.genie_sys`              | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
+| `xsec.nutau_xsec`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |

--- a/pisa/stages/GLOBALS.md
+++ b/pisa/stages/GLOBALS.md
@@ -7,16 +7,16 @@ Here we keep track of which global constants are available, what their purpose i
 
 ## Description
 
-| Constant           | Description                                                               | Default                                                               | Overwritten by environment variables (priority indicated where necessary) |
-| ------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Constant              | Description                                                               | Default                                                               | Overwritten by environment variables (priority indicated where necessary) |
+| -------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `NUMBA_CUDA_AVAIL`    | Availability of Numba's CUDA interface                                    | `False` (unless CUDA-capable GPU available)                           |                                                                           |
-| `TARGET`              | Numba compilation target                                                  | `cpu`                                                                 | `PISA_TARGET` (GPU target only possible if `NUMBA_CUDA_AVAIL`)                                                              |
+| `TARGET`              | Numba compilation target                                                  | `cpu`                                                                 | `PISA_TARGET` (GPU target only possible if `NUMBA_CUDA_AVAIL`)            |
 | `OMP_NUM_THREADS`     | Number of threads allocated to OpenMP                                     | `1`                                                                   | `OMP_NUM_THREADS`                                                         |
 | `PISA_NUM_THREADS`    | Global limit for number of threads (also upper limit for `OMP_NUM_THREADS`) | `1` (`numba.config.NUMBA_NUM_THREADS`) for `TARGET='cpu'` (`'parallel'`) | `PISA_NUM_THREADS`                                                         |
-| `PISA_HIST_THREADING` | Multi-threading mode for PISA (fast) histogramming                        | `'off'`                                                               | `PISA_HIST_THREADING`                                                         |
+| `PISA_HIST_THREADING` | Multi-threading mode for PISA (fast) histogramming                        | `'off'`                                                               | `PISA_HIST_THREADING`                                                     |
 | `FTYPE`               | Global floating-point data type                                           | `np.float64`                                                          | `PISA_FTYPE`                                                              |
-| `CTYPE`               | Global complex-valued floating-point data type                            | `np.complex128` (`np.complex64`) for `FTYPE=np.float64(32)`           |                                                                  |
-| `ITYPE`               | Global integer data type                                                  | `np.int64` (`np.int32`) for `FTYPE=np.float64(32)`                    |                                                                  |
+| `CTYPE`               | Global complex-valued floating-point data type                            | `np.complex128` (`np.complex64`) for `FTYPE=np.float64(32)`           |                                                                           |
+| `ITYPE`               | Global integer data type                                                  | `np.int64` (`np.int32`) for `FTYPE=np.float64(32)`                    |                                                                           |
 | `HASH_SIGFIGS`        | Number of significant digits used for hashing numbers, depends on `FTYPE` | `12(5)` for `FTYPE=np.float64(32)`                                    |                                                                           |
 | `EPSILON`             | Best numerical precision, derived from `HASH_SIGFIGS`                     | `10**(-HASH_SIGFIGS)`                                                 |                                                                           |
 | `C_FTYPE`             | C floating-point type corresponding to `FTYPE`                            | `'double'` (`'float'`) for `FTYPE=np.float64(32)`                     |                                                                           |
@@ -24,61 +24,63 @@ Here we keep track of which global constants are available, what their purpose i
 | `CACHE_DIR`           | Root directory for storing PISA cache files                               | `'~/.cache/pisa'`                                                     | 1.`PISA_CACHE_DIR`, 2.`XDG_CACHE_HOME/pisa`                               |
 
 ## Usage
+
 The table below depicts which services make use of a select set of global constants.
-Note that the table entries are derived both from the module files themselves (where the services are defined) and from any `pisa.utils` objects they make use of (in particular, reliance on "PISA-tailored" jit in `numba_tools`).
+Note that the table entries are derived both from the module files themselves (where the services are defined) and from any `pisa.utils` objects they make use of (e.g., reliance on "PISA-tailored" jit in `numba_tools`).
 Constants which are implicitly used by all services via `pisa.core` objects (e.g. `HASH_SIGFIGS`, `CACHE_DIR`) are not shown.
 Also note that where a service implements `FTYPE` and relies on C extension code, the simultaneous implementation of `C_FTYPE` and `C_PRECISION_DEF` is implied.
 
 **Legend**
-- :heavy_check_mark:: implements
-- :heavy_minus_sign:: does not implement but does not fail (i.e., ignores)
+- ✓: implements
+- ✗: does not implement but does not fail (i.e., ignores)
 
-|                            | `TARGET`    | `PISA_NUM_THREADS`     | `FTYPE`               | `PISA_HIST_THREADING` |
-| :------------------------: | :-------------------: | :-------------------: | :-------------------: | :-------------------: |
-| `absorption.earth_absorption` | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `aeff.aeff`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `aeff.weight`                 | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `aeff.weight_hnl`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `background.atm_muons`        | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `cont_sys.snowstorm_hist`     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `data.csv_data_hist`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.csv_icc_hist`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.csv_loader`             | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.freedom_hdf5_loader`    | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.grid`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.licloader_weighter`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.meows_loader`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.simple_data_loader`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.simple_signal`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.sqlite_loader`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `data.toy_event_generator`    | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `discr_sys.hypersurfaces`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `discr_sys.ultrasurfaces`     | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.airs`                   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.astrophysical`          | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.barr_simple`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.daemon_flux`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.hillasg`                | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.honda_ip`               | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.mceq_barr`              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
-| `flux.mceq_barr_red`          | :heavy_check_mark: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `likelihood.generalized_llh_params`   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `osc.decoherence`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `osc.globes`                  | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `osc.nusquids`                | :heavy_minus_sign:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `osc.prob3`                   | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `osc.two_nu_osc`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `reco.resolutions`            | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
-| `reco.simple_param`           | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| `utils.add_indices`           | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
-| `utils.adhoc_sys`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `utils.bootstrap`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
-| `utils.fix_error`             | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `utils.hist`                  | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark: |
-| `utils.kde`                   | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
-| `utils.kfold`                 | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `utils.resample`              | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `utils.set_variance`          | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
-| `xsec.dis_sys`                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
-| `xsec.genie_sys`              | :heavy_minus_sign:    | :heavy_minus_sign: | :heavy_minus_sign:    | :heavy_minus_sign: |
-| `xsec.nutau_xsec`             | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark:    | :heavy_minus_sign: |
+|                            | `TARGET` | `PISA_NUM_THREADS` | `FTYPE` | `PISA_HIST_THREADING` |
+| :------------------------: | :------: | :----------------: | :-----: | :-------------------: |
+| `absorption.earth_absorption` | ✗ | ✗ | ✓ | ✗ |
+| `aeff.aeff`                   | ✗ | ✗ | ✗ | ✗ |
+| `aeff.weight`                 | ✗ | ✗ | ✗ | ✗ |
+| `aeff.weight_hnl`             | ✗ | ✗ | ✗ | ✗ |
+| `background.atm_muons`        | ✗ | ✗ | ✗ | ✗ |
+| `cont_sys.snowstorm_hist`     | ✓ | ✓ | ✓ | ✓ |
+| `data.csv_data_hist`          | ✗ | ✗ | ✓ | ✗ |
+| `data.csv_icc_hist`           | ✗ | ✗ | ✓ | ✗ |
+| `data.csv_loader`             | ✗ | ✗ | ✓ | ✗ |
+| `data.freedom_hdf5_loader`    | ✗ | ✗ | ✓ | ✗ |
+| `data.grid`                   | ✗ | ✗ | ✓ | ✗ |
+| `data.licloader_weighter`     | ✗ | ✗ | ✓ | ✗ |
+| `data.meows_loader`           | ✗ | ✗ | ✓ | ✗ |
+| `data.simple_data_loader`     | ✗ | ✗ | ✓ | ✗ |
+| `data.simple_signal`          | ✗ | ✗ | ✓ | ✗ |
+| `data.sqlite_loader`          | ✗ | ✗ | ✓ | ✗ |
+| `data.toy_event_generator`    | ✗ | ✗ | ✓ | ✗ |
+| `discr_sys.hypersurfaces`     | ✗ | ✗ | ✓ | ✗ |
+| `discr_sys.ultrasurfaces`     | ✗ | ✗ | ✓ | ✗ |
+| `flux.airs`                   | ✗ | ✗ | ✓ | ✗ |
+| `flux.astrophysical`          | ✗ | ✗ | ✓ | ✗ |
+| `flux.barr_simple`            | ✓ | ✓ | ✓ | ✗ |
+| `flux.daemon_flux`            | ✗ | ✗ | ✓ | ✗ |
+| `flux.hillasg`                | ✗ | ✗ | ✓ | ✗ |
+| `flux.honda_ip`               | ✗ | ✗ | ✓ | ✗ |
+| `flux.mceq_barr`              | ✓ | ✓ | ✓ | ✗ |
+| `flux.mceq_barr_red`          | ✓ | ✗ | ✓ | ✗ |
+| `likelihood.generalized_llh_params`   | ✗ | ✗ | ✓ | ✗ |
+| `osc.decoherence`             | ✓ | ✓ | ✓ | ✗ |
+| `osc.globes`                  | ✓ | ✓ | ✓ | ✗ |
+| `osc.nusquids`                | ✗ | ✓ | ✓ | ✗ |
+| `osc.prob3`                   | ✓ | ✓ | ✓ | ✗ |
+| `osc.two_nu_osc`              | ✓ | ✓ | ✓ | ✗ |
+| `reco.resolutions`            | ✗ | ✗ | ✗ | ✗ |
+| `reco.simple_param`           | ✗ | ✗ | ✓ | ✗ |
+| `utils.add_indices`           | ✗ | ✗ | ✗ | ✗ |
+| `utils.adhoc_sys`             | ✗ | ✗ | ✓ | ✗ |
+| `utils.bootstrap`             | ✗ | ✗ | ✗ | ✗ |
+| `utils.fix_error`             | ✗ | ✗ | ✓ | ✗ |
+| `utils.hist`                  | ✓ | ✓ | ✓ | ✓ |
+| `utils.kde`                   | ✗ | ✗ | ✗ | ✗ |
+| `utils.kfold`                 | ✗ | ✗ | ✓ | ✗ |
+| `utils.resample`              | ✓ | ✓ | ✓ | ✗ |
+| `utils.set_variance`          | ✓ | ✓ | ✓ | ✗ |
+| `xsec.dis_sys`                | ✓ | ✓ | ✓ | ✗ |
+| `xsec.genie_sys`              | ✗ | ✗ | ✗ | ✗ |
+| `xsec.nutau_xsec`             | ✓ | ✓ | ✓ | ✗ |
+

--- a/pisa/utils/numba_tools.py
+++ b/pisa/utils/numba_tools.py
@@ -67,9 +67,6 @@ from pisa import FTYPE, TARGET, PISA_NUM_THREADS
 from pisa.utils.comparisons import ALLCLOSE_KW
 from pisa.utils.log import Levels, logging, set_verbosity
 
-if TARGET == "parallel":
-    numba.set_num_threads(PISA_NUM_THREADS)
-
 if TARGET is None:
     raise NotImplementedError("Numba not supported.")
 


### PR DESCRIPTION
### Changes

* Set up `numba` with correct number of threads already upon `pisa` package import (see #785)
* For [`fast_histogram` histogramming](https://github.com/icecube/pisa/blob/db24838f292d1f31a7d5a192c239e2e1f6318b44/pisa/core/translation.py#L134), setting `PISA_HIST_THREADING`  now takes precedence over `PISA_NUM_THREADS` and `PISA_TARGET`, in order to enable granular histogram threading control.
  * New default behaviour will be **no multi-threading for fast histogramming even when `PISA_NUM_THREADS > 1`**. Instead, the user needs to opt in explicitly by setting `PISA_HIST_THREADING='auto'` (recovers current default) or any integer.
* Update readme about global variables to reflect these changes (together with a few other fixes)

### Motivation

* Fixes #785 
* Multi-threaded histogramming can
  * considerably slow down `apply` of `utils.hist` (see timing data below, and through thread contention potentally/seemingly also parallel numba computations made by other services) and thereby
  *  lead to an unnecessary fit duration increase of up to a few minutes (depending on no. threads) for the example fit in https://github.com/icecube/pisa/blob/db24838f292d1f31a7d5a192c239e2e1f6318b44/pisa_examples/IceCube_3y_oscillations_example.ipynb
  
  As a result, significant gain from multi-threaded (in particular) oscillation calculations is partially compensated by the performance hit on histogramming the events in the sample&mdash;to the tune of ~ 2 minutes when going from 1 -> 12 threads.

### Timing study
#### analysed script (no octant check to speed it up&mdash;still retaining hundreds of template calculations)
```
#!/usr/bin/env python3

import pisa
from pisa.analysis.analysis import Analysis
from pisa.core.distribution_maker import DistributionMaker
from pisa.core.pipeline import Pipeline

ana = Analysis()
minimizer_cfg = pisa.utils.fileio.from_file('settings/minimizer/slsqp_ftol1e-6_eps1e-4_maxiter1000.json')

data_maker = Pipeline("settings/pipeline/IceCube_3y_data.cfg")
data = data_maker.get_outputs()

model = DistributionMaker(["settings/pipeline/IceCube_3y_neutrinos.cfg", "settings/pipeline/IceCube_3y_muons.cfg"], profile=True)

result = ana.fit_hypo(data, model, metric="mod_chi2", minimizer_settings=minimizer_cfg, fit_octants_separately=False, check_octant=False, pprint=False) # no octant check for speed up

model.report_profile()
```

#### results
* NB: all parallel operations configured to use 4 threads; no. of templates produced/minimiser iterations not constant + import/setup overhead included <-> speedup does not apply exactly to the average duration of `get_outputs`

| Configuration | Time | Speedup |
| -------------------- | -------------- | ------------- |
|Single-threaded baseline (CPU)       |                  261.43s  |  -
|Numba parallel only (no histogram threading) |           137.10s   |  1.91x
|Numba parallel + histogram threading  |     180.45s  |    1.45x
|CPU single-threaded + forced 4-thread histogram |        308.58s  | (1.18x slower)

Here we see that histogram threading always introduces overhead, whether relative to numba parallel or the baseline: the `ThreadPoolExecutor` overhead in `_threaded_fh_histogramdd` itself is the problem.

Following are two sets of neutrino `Pipeline` profile reports for more details, for configurations 2 and 4 above.
* Numba parallel only (no histogram threading):
```
Pipeline: neutrinos
- setup:        Total time (s): 3.621, n calls: 1
- run:          Total time (s): 91.620, n calls: 427, time/call (s): mean 0.215, max. 21.641, min. 0.043
- get_outputs:  Total time (s): 93.104, n calls: 427, time/call (s): mean 0.218, max. 21.644, min. 0.046
Individual services:
data csv_loader
- setup:    Total time (s): 3.308, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): 0.568, n calls: 427, time/call (s): mean 0.001, max. 0.004, min. 0.001
flux honda_ip
- setup:    Total time (s): 0.201, n calls: 1
- compute:  Total time (s): 20.187, n calls: 1
- apply:    Total time (s): +0.000, n calls: 427, time/call (s): mean +0.000, max. +0.000, min. +0.000
flux barr_simple
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): 11.531, n calls: 183, time/call (s): mean 0.063, max. 0.096, min. 0.057
- apply:    Total time (s): +0.000, n calls: 427, time/call (s): mean +0.000, max. +0.000, min. +0.000
osc prob3
- setup:    Total time (s): 0.081, n calls: 1
- compute:  Total time (s): 35.830, n calls: 161, time/call (s): mean 0.223, max. 0.297, min. 0.212
- apply:    Total time (s): 7.404, n calls: 427, time/call (s): mean 0.017, max. 1.062, min. 0.005
aeff aeff
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): +0.000, n calls: 161, time/call (s): mean +0.000, max. +0.000, min. +0.000
- apply:    Total time (s): 0.987, n calls: 427, time/call (s): mean 0.002, max. 0.005, min. 0.002
utils hist
- setup:    Total time (s): 0.025, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): 13.537, n calls: 427, time/call (s): mean 0.032, max. 0.045, min. 0.031
discr_sys hypersurfaces
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): 0.124, n calls: 205, time/call (s): mean +0.000, max. +0.000, min. +0.000
- apply:    Total time (s): 0.193, n calls: 427, time/call (s): mean +0.000, max. 0.003, min. +0.000
```
* CPU single-threaded + forced 4-thread histogram (flux.barr_simple, osc.prob3 and utils.hist times):
```
Pipeline: neutrinos
- setup:        Total time (s): 3.435, n calls: 1
- run:          Total time (s): 257.888, n calls: 499, time/call (s): mean 0.517, max. 24.587, min. 0.065
- get_outputs:  Total time (s): 260.161, n calls: 499, time/call (s): mean 0.521, max. 24.591, min. 0.069
Individual services:
data csv_loader
- setup:    Total time (s): 3.297, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): 0.742, n calls: 499, time/call (s): mean 0.001, max. 0.004, min. 0.001
flux honda_ip
- setup:    Total time (s): 0.024, n calls: 1
- compute:  Total time (s): 22.872, n calls: 1
- apply:    Total time (s): +0.000, n calls: 499, time/call (s): mean +0.000, max. +0.000, min. +0.000
flux barr_simple
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): 47.262, n calls: 200, time/call (s): mean 0.236, max. 0.302, min. 0.198
- apply:    Total time (s): +0.000, n calls: 499, time/call (s): mean +0.000, max. +0.000, min. +0.000
osc prob3
- setup:    Total time (s): 0.082, n calls: 1
- compute:  Total time (s): 145.745, n calls: 173, time/call (s): mean 0.842, max. 0.899, min. 0.796
- apply:    Total time (s): 9.374, n calls: 499, time/call (s): mean 0.019, max. 0.613, min. 0.005
aeff aeff
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): +0.000, n calls: 173, time/call (s): mean +0.000, max. +0.000, min. +0.000
- apply:    Total time (s): 1.172, n calls: 499, time/call (s): mean 0.002, max. 0.004, min. 0.002
utils hist
- setup:    Total time (s): 0.026, n calls: 1
- compute:  Total time (s): +0.000, n calls: 1
- apply:    Total time (s): 28.313, n calls: 499, time/call (s): mean 0.057, max. 0.067, min. 0.050
discr_sys hypersurfaces
- setup:    Total time (s): +0.000, n calls: 1
- compute:  Total time (s): 0.211, n calls: 227, time/call (s): mean +0.000, max. 0.001, min. +0.000
- apply:    Total time (s): 0.327, n calls: 499, time/call (s): mean +0.000, max. +0.000, min. +0.000
```