### PR TITLE
Refactor write_benchmark_json to comply with github-action-benchmark format and ensure time series creation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,3 +32,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html
+        # Destination directory in gh-pages not root but docs/
+        destination_dir: docs
+        # Don't delete other existing files
+        keep_files: true

--- a/pisa/scripts/benchmark_pipeline_performance.py
+++ b/pisa/scripts/benchmark_pipeline_performance.py
@@ -141,20 +141,21 @@ def write_benchmark_json(results, output_path, commit_sha=None, commit_msg=None)
     -------
     Path
         Path to written JSON file
+
+    Notes
+    -----
+    The github-action-benchmark tool expects the JSON file to contain
+    only the array of results, not a wrapper object. Timestamp and commit
+    information are not included in the output file but can be added back
+    if needed for other purposes.
     """
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    data = {
-        "timestamp": datetime.datetime.now(datetime.UTC).isoformat() + "Z",
-        "results": results,
-    }
+    timestamp = datetime.datetime.now(datetime.UTC).isoformat() + "Z"
 
-    if commit_sha:
-        data["commit_sha"] = commit_sha
-    if commit_msg:
-        data["commit_msg"] = commit_msg
-
+    # Write only the results array, as expected by github-action-benchmark
+    data = results
     to_file(data, output_path)
 
     return output_path
@@ -227,7 +228,8 @@ def main():
         f"results_target_{TARGET}_nthreads_{PISA_NUM_THREADS}.json"
     )
 
-    # Enrich with commit information
+    # Enrich with commit information (currently not written to file as
+    # github-action-benchmark expects only the results array)
     commit_sha = os.environ.get("GITHUB_SHA")
     commit_msg = os.environ.get("GITHUB_COMMIT_MSG")
 

--- a/setup.py
+++ b/setup.py
@@ -327,6 +327,7 @@ def do_setup():
 
                 # Scripts in scripts dir
                 'pisa-add_flux_to_events_file = pisa.scripts.add_flux_to_events_file:main',
+                'pisa-benchmark_pipeline_performance = pisa.scripts.benchmark_pipeline_performance:main',
                 'pisa-compare = pisa.scripts.compare:main',
                 'pisa-convert_config_format = pisa.scripts.convert_config_format:main',
                 'pisa-create_barr_sys_tables_mceq = pisa.scripts.create_barr_sys_tables_mceq:main',


### PR DESCRIPTION
Turns out the workflow [failed](https://github.com/icecube/pisa/actions/runs/27029770947) because the script had created dictionary entries when only a simple list of results was allowed.

* I've applied the fix in my fork and here are the plots after a successful workflow: https://thehrh.github.io/pisa-1/dev/bench (benchmarks will show up in this repository under https://icecube.github.io/pisa/dev/bench)
* An example set of .json artifacts whose data are included in the plots is available from [here](https://github.com/thehrh/pisa-1/actions/runs/27062981085)

Another problem which appeared in my branch was the automatic removal of the previous benchmarking results in the gh-pages branch by the documentation workflow.

As a result, I've adapted the documentation workflow, on the one hand, to output to `docs`, not the root directory, of gh-pages, and, more importantly, configured it to `keep_files`. This way, `dev/bench/data.js` will not get deleted and instead will be extended.

It just means we will need to set the PISA (docs) URL in the right column to icecube.github.io/pisa/docs (leaving the Pages source at `/ (root)` in [settings](https://github.com/icecube/pisa/settings/pages).

Also, **ideally before this PR is merged, we should manually delete the gh-pages branch once** so that the files currently in its root directory are removed.

In the future, the benchmark time series will then be extended as long as `dev/bench/data.js` in gh-pages isn't deleted. If &mdash;for some reason&mdash;it does get deleted at some point without there being a backup, the time series will just start anew.

Finally, an entry point for the benchmarking script is added to setup.py.