### PR TITLE
Add concurrency groups for (relevant) workflows to cancel existing run when new one starts and group dependabot actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,16 @@ updates:
       - dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"   # workflows live under .github/workflows
+    directory: "/.github/workflows"   # workflows live under /.github/workflows
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "direct"
+    # put all updates into a single PR (instead of one per dependency)
+    # see https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/benchmark_pipeline_times.yml
+++ b/.github/workflows/benchmark_pipeline_times.yml
@@ -26,6 +26,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark_pipeline_times.yml
+++ b/.github/workflows/benchmark_pipeline_times.yml
@@ -26,6 +26,8 @@ on:
         type: boolean
         default: false
 
+# cancel in-progress run for current workflow when new workflow starts
+# (github.run_id only as fallback, just in case, as per "control workflow concurrency" HOWTO)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,8 @@ on:
     tags:
       - '*'
 
+# cancel in-progress run for current workflow when new workflow starts       
+# (github.run_id only as fallback, just in case, as per "control workflow concurrency" HOWTO)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ master ]
 
+# cancel in-progress run for current workflow when new workflow starts       
+# (github.run_id only as fallback, just in case, as per "control workflow concurrency" HOWTO)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
This is intended to save resources: I do not believe it is necessary for either of these workflows to complete when a new one has already begun (consider quick successive pushes to a PR or multiple PR's being merged in quick succession).

The syntax used here is taken from:
* https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-concurrency-and-the-default-behavior and
* https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-a-fallback-value.

I haven't added concurrency control to the two release workflows because the above use case doesn't seem to apply to them.

The PR should also ensure that future actions updates by Dependabot end up in a single PR.