### PR TITLE
Remove upper python version cap in `python_requires` keyword to `setuptools.setup()`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ def do_setup():
         author_email='analysis@icecube.wisc.edu',
         url='https://github.com/icecubeopensource/pisa',
         cmdclass=cmdclasses,
-        python_requires='>=3.8,<3.15', # daemonflux 0.8.0 requires Py>=3.8
+        python_requires='>=3.8', # daemonflux 0.8.0 requires Py>=3.8
         setup_requires=SETUP_REQUIRES,
         install_requires=INSTALL_REQUIRES,
         extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
While it seems the origin of the specified range for [`python_requires`](https://setuptools.pypa.io/en/latest/references/keywords.html) lies in [PEP 345](https://peps.python.org/pep-0345/#requires-python) ("This field specifies the Python version(s) that the distribution is guaranteed to be compatible with."), I've become convinced that capping the Python version (here: < 3.15) is in fact bad practice, see https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special:

>  This is misusing a feature designed to help with dropping old Python versions to instead stop new Python versions from being used. “Scrolling back” through older releases to find the newest version that does not restrict the version of Python being used is exactly the wrong behavior for an upper cap, and that is what the purpose of this field is. All current solvers (Pip, Poetry, PDM) do not work correctly if this field is capped, and implement the scroll back behavior. To be clear, this is very different from a library: specifically, you can’t downgrade your Python version[5](https://iscinumpy.dev/post/bound-version-constraints/#fn:5) if this is capped to something below your current version. You can only fail. So this does not “fix” something by getting an older, working version, it only causes hard failures if it works the way you might hope it does. This means instead of seeing the real failure and possibly helping to fix it, users just see a “Python doesn’t match” error. And, most of the time, it’s not even a real error; if you support Python 3.x without warnings, you should support Python 3.x+1 (and 3.x+2, too).

I therefore suggest removing the cap before the next release.

