### PR TITLE
Fetch git tags when checking out repository in actions

### DIFF
--- a/.github/workflows/benchmark_pipeline_times.yml
+++ b/.github/workflows/benchmark_pipeline_times.yml
@@ -36,6 +36,8 @@ jobs:
           - { target: "parallel", nthreads: 4 } # each free ubuntu-latest runner provides 4 cpus
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-tags: true
     - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-tags: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Docker Login
         uses: docker/login-action@v4.2.0


### PR DESCRIPTION
Versioneer looks for tags that are ancestors of the current commit, but can't find any when actions/checkout is not configured with `fetch-tags: true`. One can see the result in the html docs ("**PISA 0+untagged.1.g53a4132 documentation**"), for example, but also in the log output of every workflow that has installed PISA.

Now always fetch tags in workflows so that versioneer can always create the PISA version tag.

Note that, ironically, this PR itself can't demonstrate the fix working (checks still have untagged PISA), but all future workflow runs in master will have properly tagged versions.