### PR TITLE
Ensure pisa version is correctly detected when building documentation (not just for tagged commits)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      # ensure version string in documentation starts with most recent tag (not "0+untagged")
       with:
         fetch-tags: true
+        fetch-depth: 0
     - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
It has turned out that https://github.com/icecube/pisa/pull/953 wasn't quite enough: the documentation now only reports the correct version when the commit in question is tagged, but in other cases still just `0+untagged...`.

This PR hopefully fixes these cases by adding [`fetch-depth: 0`](https://github.com/actions/checkout#usage) (fix was successful in my fork as can be seen in [this workflow run](https://github.com/thehrh/pisa-1/actions/runs/28531774654/job/84582861394)).